### PR TITLE
refactor: move block controls from TopBar to inline block controls

### DIFF
--- a/src/components/BlockControls.tsx
+++ b/src/components/BlockControls.tsx
@@ -3,10 +3,10 @@ import React from 'react';
 interface BlockControlsProps {
   canMoveUp: boolean;
   canMoveDown: boolean;
-  onMoveUp: () => void;
-  onMoveDown: () => void;
-  onDuplicate: () => void;
-  onRemove: () => void;
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
+  onDuplicate?: () => void;
+  onRemove?: () => void;
 }
 
 const BlockControls: React.FC<BlockControlsProps> = ({
@@ -19,7 +19,7 @@ const BlockControls: React.FC<BlockControlsProps> = ({
 }) => {
   return (
     <div className="absolute top-2 right-2 z-50 flex flex-row gap-1 bg-white/95 backdrop-blur-sm rounded-lg shadow-lg border border-gray-200 p-1">
-      {canMoveUp && (
+      {canMoveUp && onMoveUp && (
         <button
           onClick={(e) => {
             e.stopPropagation();
@@ -34,7 +34,7 @@ const BlockControls: React.FC<BlockControlsProps> = ({
         </button>
       )}
       
-      {canMoveDown && (
+      {canMoveDown && onMoveDown && (
         <button
           onClick={(e) => {
             e.stopPropagation();
@@ -49,31 +49,35 @@ const BlockControls: React.FC<BlockControlsProps> = ({
         </button>
       )}
       
-      <button
-        onClick={(e) => {
-          e.stopPropagation();
-          onDuplicate();
-        }}
-        className="w-7 h-7 flex items-center justify-center text-gray-600 hover:text-green-600 hover:bg-green-50 rounded transition-colors"
-        title="Duplicate"
-      >
-        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-        </svg>
-      </button>
+      {onDuplicate && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onDuplicate();
+          }}
+          className="w-7 h-7 flex items-center justify-center text-gray-600 hover:text-green-600 hover:bg-green-50 rounded transition-colors"
+          title="Duplicate"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+          </svg>
+        </button>
+      )}
       
-      <button
-        onClick={(e) => {
-          e.stopPropagation();
-          onRemove();
-        }}
-        className="w-7 h-7 flex items-center justify-center text-gray-600 hover:text-red-600 hover:bg-red-50 rounded transition-colors"
-        title="Remove"
-      >
-        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-        </svg>
-      </button>
+      {onRemove && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+          className="w-7 h-7 flex items-center justify-center text-gray-600 hover:text-red-600 hover:bg-red-50 rounded transition-colors"
+          title="Remove"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+          </svg>
+        </button>
+      )}
     </div>
   );
 };

--- a/src/components/BlockControls.tsx
+++ b/src/components/BlockControls.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+
+interface BlockControlsProps {
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onDuplicate: () => void;
+  onRemove: () => void;
+}
+
+const BlockControls: React.FC<BlockControlsProps> = ({
+  canMoveUp,
+  canMoveDown,
+  onMoveUp,
+  onMoveDown,
+  onDuplicate,
+  onRemove
+}) => {
+  return (
+    <div className="absolute top-2 right-2 z-50 flex flex-row gap-1 bg-white/95 backdrop-blur-sm rounded-lg shadow-lg border border-gray-200 p-1">
+      {canMoveUp && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onMoveUp();
+          }}
+          className="w-7 h-7 flex items-center justify-center text-gray-600 hover:text-blue-600 hover:bg-blue-50 rounded transition-colors"
+          title="Move Up"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+          </svg>
+        </button>
+      )}
+      
+      {canMoveDown && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onMoveDown();
+          }}
+          className="w-7 h-7 flex items-center justify-center text-gray-600 hover:text-blue-600 hover:bg-blue-50 rounded transition-colors"
+          title="Move Down"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+      )}
+      
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onDuplicate();
+        }}
+        className="w-7 h-7 flex items-center justify-center text-gray-600 hover:text-green-600 hover:bg-green-50 rounded transition-colors"
+        title="Duplicate"
+      >
+        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+        </svg>
+      </button>
+      
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onRemove();
+        }}
+        className="w-7 h-7 flex items-center justify-center text-gray-600 hover:text-red-600 hover:bg-red-50 rounded transition-colors"
+        title="Remove"
+      >
+        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+        </svg>
+      </button>
+    </div>
+  );
+};
+
+export default BlockControls; 

--- a/src/components/BlockRenderer.tsx
+++ b/src/components/BlockRenderer.tsx
@@ -40,27 +40,19 @@ const BlockRenderer: React.FC<BlockRendererProps> = ({
 
   // Block control handlers
   const handleMoveUp = () => {
-    if (isSelected) {
-      moveBlockUp();
-    }
+    moveBlockUp();
   };
 
   const handleMoveDown = () => {
-    if (isSelected) {
-      moveBlockDown();
-    }
+    moveBlockDown();
   };
 
   const handleDuplicate = () => {
-    if (isSelected) {
-      duplicateSelectedBlock();
-    }
+    duplicateSelectedBlock();
   };
 
   const handleRemove = () => {
-    if (isSelected) {
-      deleteSelectedBlock();
-    }
+    deleteSelectedBlock();
   };
 
   // Evaluate visibility before rendering

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,79 +1,11 @@
 import React from 'react';
-import { useSelection } from '../context/SelectionContext';
-import { findBlockPositionForUI } from '../utils/blockUtils';
-import Dropdown, { DropdownItem } from './Dropdown';
 
 const TopBar: React.FC = () => {
-  const { 
-    selectedBlockId, 
-    pageSchema, 
-    moveBlockUp, 
-    moveBlockDown,
-    deleteSelectedBlock,
-    duplicateSelectedBlock
-  } = useSelection();
-
-  const position = selectedBlockId ? findBlockPositionForUI(selectedBlockId, pageSchema.blocks) : null;
-  const isFirst = position ? position.index === 0 : true;
-  const isLast = position ? position.index === position.totalSiblings - 1 : true;
-  const hasSelectedBlock = selectedBlockId && position && position.index !== -1;
-
   return (
     <div className="bg-gray-800 text-white p-4 border-b border-gray-700">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-bold">Flimix Studio</h1>
         <div className="flex items-center space-x-4">
-          {/* Block Actions */}
-          {hasSelectedBlock && (
-            <div className="flex items-center space-x-2 bg-gray-700 rounded-lg px-3 py-2">
-              <span className="text-sm text-gray-300 mr-2">
-                {position?.isTopLevel ? 'Block Actions' : 'Block Actions (within parent)'}
-              </span>
-              <button
-                onClick={moveBlockUp}
-                disabled={isFirst}
-                className={`
-                  px-3 py-1 rounded text-sm font-medium transition-colors
-                  ${isFirst 
-                    ? 'bg-gray-600 text-gray-400 cursor-not-allowed' 
-                    : 'bg-blue-600 text-white hover:bg-blue-700 active:bg-blue-800'
-                  }
-                `}
-                title="Move Block Up"
-              >
-                ⬆️
-              </button>
-              <button
-                onClick={moveBlockDown}
-                disabled={isLast}
-                className={`
-                  px-3 py-1 rounded text-sm font-medium transition-colors
-                  ${isLast 
-                    ? 'bg-gray-600 text-gray-400 cursor-not-allowed' 
-                    : 'bg-blue-600 text-white hover:bg-blue-700 active:bg-blue-800'
-                  }
-                `}
-                title="Move Block Down"
-              >
-                ⬇️
-              </button>
-              <Dropdown
-                trigger={
-                  <button className="px-3 py-1 rounded text-sm font-medium transition-colors bg-gray-600 text-white hover:bg-gray-700 active:bg-gray-800">
-                    ⋯
-                  </button>
-                }
-              >
-                <DropdownItem onClick={duplicateSelectedBlock}>
-                  Copy
-                </DropdownItem>
-                <DropdownItem onClick={deleteSelectedBlock}>
-                  Remove
-                </DropdownItem>
-              </Dropdown>
-            </div>
-          )}
-          
           <button className="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded">
             Save
           </button>

--- a/src/components/blocks/BaseBlock.tsx
+++ b/src/components/blocks/BaseBlock.tsx
@@ -69,7 +69,7 @@ const BaseBlock: React.FC<BaseBlockProps> = ({
       {children}
       
       {/* Show block controls when selected */}
-      {isSelected && onMoveUp && onMoveDown && onDuplicate && onRemove && (
+      {isSelected && (onMoveUp || onMoveDown || onDuplicate || onRemove) && (
         <BlockControls
           canMoveUp={canMoveUp}
           canMoveDown={canMoveDown}

--- a/src/components/blocks/BaseBlock.tsx
+++ b/src/components/blocks/BaseBlock.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import BlockControls from '../BlockControls';
 import type { Block } from '../../schema/blockTypes';
 
 export interface BaseBlockProps {
@@ -8,6 +9,13 @@ export interface BaseBlockProps {
   children?: React.ReactNode;
   className?: string;
   style?: React.CSSProperties;
+  // Block control props
+  canMoveUp?: boolean;
+  canMoveDown?: boolean;
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
+  onDuplicate?: () => void;
+  onRemove?: () => void;
 }
 
 /**
@@ -17,6 +25,7 @@ export interface BaseBlockProps {
  * - Selection state management
  * - Common styling for selected state
  * - Extensible render method
+ * - Inline block controls when selected
  */
 const BaseBlock: React.FC<BaseBlockProps> = ({ 
   block, 
@@ -24,7 +33,13 @@ const BaseBlock: React.FC<BaseBlockProps> = ({
   isSelected = false, 
   children,
   className = '',
-  style = {}
+  style = {},
+  canMoveUp = false,
+  canMoveDown = false,
+  onMoveUp,
+  onMoveDown,
+  onDuplicate,
+  onRemove
 }) => {
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation(); // Prevent event bubbling to parent blocks
@@ -35,6 +50,8 @@ const BaseBlock: React.FC<BaseBlockProps> = ({
     'cursor-pointer',
     'transition-all',
     'duration-200',
+    'relative', // Added for absolute positioning of controls
+    'overflow-visible', // Ensure controls are visible even if they extend beyond block bounds
     isSelected ? 'ring-2 ring-blue-500' : '',
     className
   ].filter(Boolean).join(' ');
@@ -42,10 +59,26 @@ const BaseBlock: React.FC<BaseBlockProps> = ({
   return (
     <div 
       className={baseClasses}
-      style={style}
+      style={{
+        ...style,
+        // Add padding when selected to prevent content overlap with controls
+        paddingRight: isSelected ? '3rem' : undefined
+      }}
       onClick={handleClick}
     >
       {children}
+      
+      {/* Show block controls when selected */}
+      {isSelected && onMoveUp && onMoveDown && onDuplicate && onRemove && (
+        <BlockControls
+          canMoveUp={canMoveUp}
+          canMoveDown={canMoveDown}
+          onMoveUp={onMoveUp}
+          onMoveDown={onMoveDown}
+          onDuplicate={onDuplicate}
+          onRemove={onRemove}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/blocks/HeroBlock.tsx
+++ b/src/components/blocks/HeroBlock.tsx
@@ -7,7 +7,17 @@ interface HeroBlockProps extends Omit<BaseBlockProps, 'block'> {
   block: HeroBlockType;
 }
 
-const HeroBlock: React.FC<HeroBlockProps> = ({ block, onSelect, isSelected = false }) => {
+const HeroBlock: React.FC<HeroBlockProps> = ({ 
+  block, 
+  onSelect, 
+  isSelected = false,
+  canMoveUp,
+  canMoveDown,
+  onMoveUp,
+  onMoveDown,
+  onDuplicate,
+  onRemove
+}) => {
   const { props, style } = block;
   const { title, subtitle, backgroundImage, ctaButton } = props;
   
@@ -31,6 +41,12 @@ const HeroBlock: React.FC<HeroBlockProps> = ({ block, onSelect, isSelected = fal
       block={block} 
       onSelect={onSelect} 
       isSelected={isSelected}
+      canMoveUp={canMoveUp}
+      canMoveDown={canMoveDown}
+      onMoveUp={onMoveUp}
+      onMoveDown={onMoveDown}
+      onDuplicate={onDuplicate}
+      onRemove={onRemove}
       className={`relative rounded-lg overflow-hidden ${paddingClass} ${backgroundClass}`}
       style={{
         backgroundImage: backgroundImage ? `url(${backgroundImage})` : undefined,

--- a/src/components/blocks/SectionBlock.tsx
+++ b/src/components/blocks/SectionBlock.tsx
@@ -19,7 +19,13 @@ const SectionBlock: React.FC<SectionBlockProps> = ({
   showDebug = false, 
   onSelect, 
   isSelected = false,
-  selectedBlockId
+  selectedBlockId,
+  canMoveUp,
+  canMoveDown,
+  onMoveUp,
+  onMoveDown,
+  onDuplicate,
+  onRemove
 }) => {
   const { props, style, children } = block;
   const { title, description } = props;
@@ -50,6 +56,12 @@ const SectionBlock: React.FC<SectionBlockProps> = ({
       block={block} 
       onSelect={onSelect} 
       isSelected={isSelected}
+      canMoveUp={canMoveUp}
+      canMoveDown={canMoveDown}
+      onMoveUp={onMoveUp}
+      onMoveDown={onMoveDown}
+      onDuplicate={onDuplicate}
+      onRemove={onRemove}
       className={`${paddingClass} ${marginClass} ${borderRadiusClass} ${boxShadowClass} ${
         isDark ? 'bg-gray-800' : 'bg-white'
       }`}

--- a/src/components/blocks/TextBlock.tsx
+++ b/src/components/blocks/TextBlock.tsx
@@ -1,13 +1,23 @@
 import React from 'react';
 import BaseBlock from './BaseBlock';
 import type { BaseBlockProps } from './BaseBlock';
-import type { TextBlock as TextBlockType, Theme, Padding } from '../../schema/blockTypes';
+import type { TextBlock as TextBlockType } from '../../schema/blockTypes'; 
 
 interface TextBlockProps extends Omit<BaseBlockProps, 'block'> {
   block: TextBlockType;
 }
 
-const TextBlock: React.FC<TextBlockProps> = ({ block, onSelect, isSelected = false }) => {
+const TextBlock: React.FC<TextBlockProps> = ({ 
+  block, 
+  onSelect, 
+  isSelected = false,
+  canMoveUp,
+  canMoveDown,
+  onMoveUp,
+  onMoveDown,
+  onDuplicate,
+  onRemove
+}) => {
   const { props, style } = block;
   const { content } = props;
   
@@ -16,6 +26,9 @@ const TextBlock: React.FC<TextBlockProps> = ({ block, onSelect, isSelected = fal
                       style?.padding === 'md' ? 'p-6' : 
                       style?.padding === 'sm' ? 'p-4' : 'p-6';
   
+  const textAlignClass = style?.textAlign === 'center' ? 'text-center' :
+                        style?.textAlign === 'right' ? 'text-right' : 'text-left';
+
   // Handle text color - if it's a hex value, use inline style, otherwise use Tailwind class
   const isHexColor = style?.textColor && style.textColor.startsWith('#');
   const textColorClass = !isHexColor ? (style?.textColor || (isDark ? 'text-white' : 'text-gray-800')) : '';
@@ -32,6 +45,12 @@ const TextBlock: React.FC<TextBlockProps> = ({ block, onSelect, isSelected = fal
         block={block} 
         onSelect={onSelect} 
         isSelected={isSelected}
+        canMoveUp={canMoveUp}
+        canMoveDown={canMoveDown}
+        onMoveUp={onMoveUp}
+        onMoveDown={onMoveDown}
+        onDuplicate={onDuplicate}
+        onRemove={onRemove}
         className={`${paddingClass} bg-gray-50 rounded-lg border-2 border-dashed border-gray-300`}
         style={hasCustomBackground ? { backgroundColor: style.backgroundColor } : undefined}
       >
@@ -45,11 +64,17 @@ const TextBlock: React.FC<TextBlockProps> = ({ block, onSelect, isSelected = fal
       block={block} 
       onSelect={onSelect} 
       isSelected={isSelected}
-      className={`${paddingClass} ${backgroundClass} rounded-lg`}
+      canMoveUp={canMoveUp}
+      canMoveDown={canMoveDown}
+      onMoveUp={onMoveUp}
+      onMoveDown={onMoveDown}
+      onDuplicate={onDuplicate}
+      onRemove={onRemove}
+      className={`${paddingClass} ${backgroundClass} rounded-lg shadow-sm`}
       style={hasCustomBackground ? { backgroundColor: style.backgroundColor } : undefined}
     >
-      <div className={`max-w-4xl mx-auto ${textColorClass}`} style={textColorStyle}>
-        <p className="text-lg leading-relaxed">
+      <div className={`max-w-4xl mx-auto ${textAlignClass}`}>
+        <p className={`text-lg leading-relaxed ${textColorClass}`} style={textColorStyle}>
           {content}
         </p>
       </div>


### PR DESCRIPTION
- Create BlockControls component for inline block actions
- Move block control logic from TopBar to individual block components
- Update BaseBlock to render controls when block is selected
- Pass control props through BlockRenderer to all block types
- Improve control styling with modern design and hover states
- Remove redundant block controls from TopBar
- Fix text alignment handling in TextBlock component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline controls to blocks for moving up, moving down, duplicating, and removing directly within the editor.
  * Blocks now display action buttons only when selected for a cleaner interface.

* **Improvements**
  * Block controls have been removed from the top bar and are now accessible inline, streamlining the editing experience.
  * Enhanced text alignment and styling options in text blocks for improved appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->