### PR TITLE
feat: add block inserter sidebar with predefined block catalog

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import TopBar from './components/TopBar';
 import Canvas from './components/Canvas';
 import Sidebar from './components/Sidebar';
+import BlockInserterSidebar from './components/BlockInserterSidebar';
 import { SelectionProvider } from './context/SelectionContext';
 import type { PageSchema, Theme, Platform } from './schema/blockTypes';
 
@@ -128,6 +129,7 @@ function App() {
       <div className="h-screen flex flex-col bg-gray-50">
         <TopBar />
         <div className="flex-1 flex">
+          <BlockInserterSidebar />
           <Canvas />
           <Sidebar />
         </div>

--- a/src/components/BlockInserterSidebar.tsx
+++ b/src/components/BlockInserterSidebar.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { Plus, Layout, Type, Square } from 'lucide-react';
+import { useSelection } from '../context/SelectionContext';
+import { getAllBlockTemplates } from '../schema/blockTemplates';
+
+// Icon mapping for the templates
+const iconMap = {
+  Layout,
+  Type,
+  Square
+};
+
+const BlockInserterSidebar: React.FC = () => {
+  const { selectedBlockId, insertBlockBefore, insertBlockAtEnd } = useSelection();
+
+  const handleBlockInsert = (blockType: string) => {
+    if (selectedBlockId) {
+      // Insert before the currently selected block
+      insertBlockBefore(blockType);
+    } else {
+      // If no block is selected, insert at the end of the page
+      insertBlockAtEnd(blockType);
+    }
+  };
+
+  // Get all block templates using the helper function
+  const allTemplates = getAllBlockTemplates();
+
+  return (
+    <div className="w-64 bg-white border-r border-gray-200 flex flex-col">
+      {/* Header */}
+      <div className="p-4 border-b border-gray-200">
+        <h2 className="text-lg font-semibold text-gray-800">Block Library</h2>
+        <p className="text-sm text-gray-600 mt-1">
+          Click to insert blocks into your page
+        </p>
+      </div>
+
+      {/* Block Templates */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-3">
+        {allTemplates.map((template) => {
+          const IconComponent = iconMap[template.icon as keyof typeof iconMap] || Layout;
+          
+          return (
+            <button
+              key={template.type}
+              onClick={() => handleBlockInsert(template.type)}
+              className="w-full p-4 text-left bg-white border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all duration-200 group"
+            >
+              <div className="flex items-center space-x-3">
+                {/* Icon */}
+                <div className={`w-10 h-10 rounded-lg flex items-center justify-center text-white ${template.color}`}>
+                  <IconComponent size={20} />
+                </div>
+                
+                {/* Content */}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center justify-between">
+                    <h3 className="font-medium text-gray-900 group-hover:text-blue-600 transition-colors">
+                      {template.name}
+                    </h3>
+                    <Plus 
+                      size={16} 
+                      className="text-gray-400 group-hover:text-blue-500 transition-colors" 
+                    />
+                  </div>
+                  <p className="text-sm text-gray-600 mt-1 line-clamp-2">
+                    {template.description}
+                  </p>
+                </div>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Footer */}
+      <div className="p-4 border-t border-gray-200 bg-gray-50">
+        <div className="text-xs text-gray-500">
+          {selectedBlockId ? (
+            <span>Will insert before selected block</span>
+          ) : (
+            <span>Will insert at the end of the page</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BlockInserterSidebar; 

--- a/src/components/BlockInserterSidebar.tsx
+++ b/src/components/BlockInserterSidebar.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Plus, Layout, Type, Square } from 'lucide-react';
 import { useSelection } from '../context/SelectionContext';
 import { getAllBlockTemplates } from '../schema/blockTemplates';
+import type { BlockType } from '../schema/blockTypes';
 
 // Icon mapping for the templates
 const iconMap = {
@@ -13,7 +14,7 @@ const iconMap = {
 const BlockInserterSidebar: React.FC = () => {
   const { selectedBlockId, insertBlockBefore, insertBlockAtEnd } = useSelection();
 
-  const handleBlockInsert = (blockType: string) => {
+  const handleBlockInsert = (blockType: BlockType['type']) => {
     if (selectedBlockId) {
       // Insert before the currently selected block
       insertBlockBefore(blockType);
@@ -39,7 +40,7 @@ const BlockInserterSidebar: React.FC = () => {
       {/* Block Templates */}
       <div className="flex-1 overflow-y-auto p-4 space-y-3">
         {allTemplates.map((template) => {
-          const IconComponent = iconMap[template.icon as keyof typeof iconMap] || Layout;
+          const IconComponent = iconMap[template.icon] || Layout;
           
           return (
             <button

--- a/src/context/SelectionContext.tsx
+++ b/src/context/SelectionContext.tsx
@@ -4,6 +4,7 @@ import type { Block, PageSchema, StyleProps, BlockType } from '../schema/blockTy
 import { swap } from '../utils/arrayUtils';
 import { findBlockAndParent, updateParentChildren, findBlockPositionById, cloneBlockWithNewIds } from '../utils/blockUtils';
 import { createBlock } from '../utils/createBlock';
+import { getAvailableBlockTypes } from '../schema/blockTemplates';
 
 interface SelectionContextType {
   selectedBlock: Block | null;
@@ -21,6 +22,7 @@ interface SelectionContextType {
   duplicateSelectedBlock: () => void;
   insertBlockAfter: (blockType: BlockType['type']) => void;
   insertBlockBefore: (blockType: BlockType['type']) => void;
+  insertBlockAtEnd: (blockType: BlockType['type']) => void;
 }
 
 const SelectionContext = createContext<SelectionContextType | undefined>(undefined);
@@ -330,6 +332,13 @@ export const SelectionProvider: React.FC<SelectionProviderProps> = ({ children, 
   const insertBlockAfter = (blockType: BlockType['type']) => {
     if (!selectedBlockId) return;
     
+    // Validate block type
+    const availableTypes = getAvailableBlockTypes();
+    if (!availableTypes.includes(blockType)) {
+      console.error(`Invalid block type: ${blockType}. Available types: ${availableTypes.join(', ')}`);
+      return;
+    }
+    
     const result = findBlockPositionById(pageSchema.blocks, selectedBlockId);
     if (!result) return;
 
@@ -367,6 +376,13 @@ export const SelectionProvider: React.FC<SelectionProviderProps> = ({ children, 
   const insertBlockBefore = (blockType: BlockType['type']) => {
     if (!selectedBlockId) return;
     
+    // Validate block type
+    const availableTypes = getAvailableBlockTypes();
+    if (!availableTypes.includes(blockType)) {
+      console.error(`Invalid block type: ${blockType}. Available types: ${availableTypes.join(', ')}`);
+      return;
+    }
+    
     const result = findBlockPositionById(pageSchema.blocks, selectedBlockId);
     if (!result) return;
 
@@ -401,6 +417,31 @@ export const SelectionProvider: React.FC<SelectionProviderProps> = ({ children, 
     setSelectedBlockParentId(result.parent?.id || null);
   };
 
+  const insertBlockAtEnd = (blockType: string) => {
+    // Validate block type
+    const availableTypes = getAvailableBlockTypes();
+    if (!availableTypes.includes(blockType)) {
+      console.error(`Invalid block type: ${blockType}. Available types: ${availableTypes.join(', ')}`);
+      return;
+    }
+    
+    // Create new block using the factory function
+    const newBlock = createBlock(blockType);
+    
+    // Add the new block to the end of the page
+    const updatedSchema = {
+      ...pageSchema,
+      blocks: [...pageSchema.blocks, newBlock]
+    };
+    
+    setPageSchema(updatedSchema);
+    
+    // Select the newly inserted block
+    setSelectedBlockId(newBlock.id);
+    setSelectedBlock(newBlock as Block);
+    setSelectedBlockParentId(null);
+  };
+
   return (
     <SelectionContext.Provider value={{
       selectedBlock,
@@ -417,7 +458,8 @@ export const SelectionProvider: React.FC<SelectionProviderProps> = ({ children, 
       deleteSelectedBlock,
       duplicateSelectedBlock,
       insertBlockAfter,
-      insertBlockBefore
+      insertBlockBefore,
+      insertBlockAtEnd
     }}>
       {children}
     </SelectionContext.Provider>

--- a/src/context/SelectionContext.tsx
+++ b/src/context/SelectionContext.tsx
@@ -38,6 +38,16 @@ export const SelectionProvider: React.FC<SelectionProviderProps> = ({ children, 
   const [selectedBlockParentId, setSelectedBlockParentId] = useState<string | null>(null);
   const [pageSchema, setPageSchema] = useState<PageSchema>(initialSchema);
 
+  // Helper function to validate block types
+  const isBlockTypeValid = (blockType: string): boolean => {
+    const availableTypes = getAvailableBlockTypes();
+    if (!availableTypes.includes(blockType)) {
+      console.error(`Invalid block type: ${blockType}. Available types: ${availableTypes.join(', ')}`);
+      return false;
+    }
+    return true;
+  };
+
   const updateSelectedBlockProps = (newProps: Partial<Block['props']>) => {
     if (!selectedBlock) return;
 
@@ -333,9 +343,7 @@ export const SelectionProvider: React.FC<SelectionProviderProps> = ({ children, 
     if (!selectedBlockId) return;
     
     // Validate block type
-    const availableTypes = getAvailableBlockTypes();
-    if (!availableTypes.includes(blockType)) {
-      console.error(`Invalid block type: ${blockType}. Available types: ${availableTypes.join(', ')}`);
+    if (!isBlockTypeValid(blockType)) {
       return;
     }
     
@@ -377,9 +385,7 @@ export const SelectionProvider: React.FC<SelectionProviderProps> = ({ children, 
     if (!selectedBlockId) return;
     
     // Validate block type
-    const availableTypes = getAvailableBlockTypes();
-    if (!availableTypes.includes(blockType)) {
-      console.error(`Invalid block type: ${blockType}. Available types: ${availableTypes.join(', ')}`);
+    if (!isBlockTypeValid(blockType)) {
       return;
     }
     
@@ -417,11 +423,9 @@ export const SelectionProvider: React.FC<SelectionProviderProps> = ({ children, 
     setSelectedBlockParentId(result.parent?.id || null);
   };
 
-  const insertBlockAtEnd = (blockType: string) => {
+  const insertBlockAtEnd = (blockType: BlockType['type']) => {
     // Validate block type
-    const availableTypes = getAvailableBlockTypes();
-    if (!availableTypes.includes(blockType)) {
-      console.error(`Invalid block type: ${blockType}. Available types: ${availableTypes.join(', ')}`);
+    if (!isBlockTypeValid(blockType)) {
       return;
     }
     

--- a/src/schema/blockTemplates.ts
+++ b/src/schema/blockTemplates.ts
@@ -1,0 +1,42 @@
+// Block template definitions for the inserter sidebar
+export interface BlockTemplate {
+  type: string;
+  name: string;
+  description: string;
+  icon: string;
+  color: string;
+}
+
+export const blockTemplates: BlockTemplate[] = [
+  {
+    type: 'hero',
+    name: 'Hero Block',
+    description: 'Large banner with title, subtitle, and CTA button',
+    icon: 'Layout',
+    color: 'bg-gradient-to-r from-blue-500 to-purple-600'
+  },
+  {
+    type: 'text',
+    name: 'Text Block',
+    description: 'Simple text content with formatting options',
+    icon: 'Type',
+    color: 'bg-gradient-to-r from-green-500 to-teal-600'
+  },
+  {
+    type: 'section',
+    name: 'Section Block',
+    description: 'Container for organizing multiple blocks',
+    icon: 'Square',
+    color: 'bg-gradient-to-r from-orange-500 to-red-600'
+  }
+];
+
+// Helper function to get available block types
+export function getAvailableBlockTypes(): string[] {
+  return blockTemplates.map(template => template.type);
+}
+
+// Helper function to get all block templates
+export function getAllBlockTemplates(): BlockTemplate[] {
+  return [...blockTemplates];
+} 

--- a/src/schema/blockTemplates.ts
+++ b/src/schema/blockTemplates.ts
@@ -1,9 +1,11 @@
+import type { BlockType } from './blockTypes';
+
 // Block template definitions for the inserter sidebar
 export interface BlockTemplate {
-  type: string;
+  type: BlockType['type'];
   name: string;
   description: string;
-  icon: string;
+  icon: 'Layout' | 'Type' | 'Square';
   color: string;
 }
 


### PR DESCRIPTION
- Create BlockInserterSidebar component for adding new blocks to the page
- Add blockTemplates.ts with predefined block catalog and metadata
- Integrate BlockInserterSidebar into main App layout
- Extend SelectionContext with insertBlockAtEnd functionality
- Add block type validation for insert operations
- Support inserting blocks before selected block or at page end
- Include visual catalog with icons, descriptions, and color coding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a sidebar for inserting blocks, allowing users to browse and add predefined block templates to their page.
  * Added a visually enhanced block inserter interface with icons, descriptions, and color indicators for each block type.
  * Users can insert blocks at specific positions based on their current selection or at the end of the page if no selection is made.

* **Improvements**
  * Enhanced validation to ensure only available block types can be inserted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->