### PR TITLE
feat: Add item reordering and removal controls in poster-grid block

### DIFF
--- a/src/blocks/poster-grid/widget.tsx
+++ b/src/blocks/poster-grid/widget.tsx
@@ -3,6 +3,7 @@ import BaseWidget from '@blocks/shared/BaseWidget';
 import type { BaseWidgetProps } from '@blocks/shared/BaseWidget';
 import type { PosterGridBlock } from './schema';
 import { useSelection } from '@context/SelectionContext';
+import ItemsControl from '@blocks/shared/ItemsControl';
 
 interface PosterGridWidgetProps extends Omit<BaseWidgetProps<PosterGridBlock>, 'block'> {
   block: PosterGridBlock;
@@ -21,7 +22,7 @@ const PosterGridWidget: React.FC<PosterGridWidgetProps> = ({
 }) => {
   const { props, style } = block;
   const { title, layout, itemShape, items } = props;
-  const { addBlockItem, selectArrayItem, isItemSelected } = useSelection();
+  const { addBlockItem, selectArrayItem, isItemSelected, moveBlockItemLeft, moveBlockItemRight, removeBlockItem } = useSelection();
   
   const isDark = style?.theme === 'dark';
   const paddingClass = style?.padding === 'lg' ? 'p-8' : 
@@ -125,7 +126,7 @@ const PosterGridWidget: React.FC<PosterGridWidgetProps> = ({
           </h2>
         )}
         <div className={getLayoutClass()}>
-          {items.map(item => (
+          {items.map((item, index) => (
             <div key={item.id} className="relative">
               <a
                 href={item.link || '#'}
@@ -152,6 +153,13 @@ const PosterGridWidget: React.FC<PosterGridWidgetProps> = ({
                   </p>
                 )}
               </a>
+              <ItemsControl 
+                index={index}
+                count={items.length}
+                onMoveLeft={() => moveBlockItemLeft(block.id, index)}
+                onMoveRight={() => moveBlockItemRight(block.id, index)}
+                onRemove={() => removeBlockItem(block.id, item.id)}
+              />
             </div>
           ))}
         </div>

--- a/src/blocks/settings/ItemForm.tsx
+++ b/src/blocks/settings/ItemForm.tsx
@@ -1,7 +1,6 @@
 interface ItemFormProps<T extends { id: string }> {
   item: T;
   onChange: (updatedItem: T) => void;
-  onRemove: () => void;
   title: string; // Add title prop
   fields: Array<{
     key: keyof T;
@@ -15,7 +14,6 @@ interface ItemFormProps<T extends { id: string }> {
 const ItemForm = <T extends { id: string }>({ 
   item, 
   onChange, 
-  onRemove, 
   title, // Add title parameter
   fields 
 }: ItemFormProps<T>) => {
@@ -68,12 +66,6 @@ const ItemForm = <T extends { id: string }>({
     <div className="p-4 bg-gray-50 rounded-lg">
       <div className="flex justify-between items-center mb-4">
         <h3 className="font-medium text-gray-700">{title}</h3>
-        <button
-          onClick={onRemove}
-          className="text-red-600 hover:text-red-800 text-sm"
-        >
-          Remove
-        </button>
       </div>
       
       <div className="space-y-3">

--- a/src/blocks/shared/ItemsControl.tsx
+++ b/src/blocks/shared/ItemsControl.tsx
@@ -23,28 +23,29 @@ const ItemsControl: React.FC<ItemsControlProps> = ({
   showRemoveControl = true,
 }) => (
   <div className={className}>
-    {/* Move Left */}
+    {/* Move Controls */}
     {showMoveControls && (
-      <button
-        onClick={e => { e.stopPropagation(); onMoveLeft(); }}
-        disabled={index === 0}
-        className="p-1 disabled:opacity-50 hover:bg-gray-100 rounded"
-        title="Move Left"
-      >
-        <MoveLeft size={12} />
-      </button>
-    )}
+      <>
+        {/* Move Left */}
+        <button
+          onClick={e => { e.stopPropagation(); onMoveLeft(); }}
+          disabled={index === 0}
+          className="p-1 disabled:opacity-50 hover:bg-gray-100 rounded"
+          title="Move Left"
+        >
+          <MoveLeft size={12} />
+        </button>
 
-    {/* Move Right */}
-    {showMoveControls && (
-      <button
-        onClick={e => { e.stopPropagation(); onMoveRight(); }}
-        disabled={index === count - 1}
-        className="p-1 disabled:opacity-50 hover:bg-gray-100 rounded"
-        title="Move Right"
-      >
-        <MoveRight size={12} />
-      </button>
+        {/* Move Right */}
+        <button
+          onClick={e => { e.stopPropagation(); onMoveRight(); }}
+          disabled={index === count - 1}
+          className="p-1 disabled:opacity-50 hover:bg-gray-100 rounded"
+          title="Move Right"
+        >
+          <MoveRight size={12} />
+        </button>
+      </>
     )}
 
     {/* Remove */}

--- a/src/blocks/shared/ItemsControl.tsx
+++ b/src/blocks/shared/ItemsControl.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { MoveLeft, MoveRight, Trash2 } from 'lucide-react';
+
+export interface ItemsControlProps {
+  index: number;
+  count: number;
+  onMoveLeft: () => void;
+  onMoveRight: () => void;
+  onRemove: () => void;
+  className?: string;
+  showMoveControls?: boolean;
+  showRemoveControl?: boolean;
+}
+
+const ItemsControl: React.FC<ItemsControlProps> = ({
+  index,
+  count,
+  onMoveLeft,
+  onMoveRight,
+  onRemove,
+  className = "absolute top-1 right-1 flex space-x-1 bg-white/80 rounded p-1 shadow-sm",
+  showMoveControls = true,
+  showRemoveControl = true,
+}) => (
+  <div className={className}>
+    {/* Move Left */}
+    {showMoveControls && (
+      <button
+        onClick={e => { e.stopPropagation(); onMoveLeft(); }}
+        disabled={index === 0}
+        className="p-1 disabled:opacity-50 hover:bg-gray-100 rounded"
+        title="Move Left"
+      >
+        <MoveLeft size={12} />
+      </button>
+    )}
+
+    {/* Move Right */}
+    {showMoveControls && (
+      <button
+        onClick={e => { e.stopPropagation(); onMoveRight(); }}
+        disabled={index === count - 1}
+        className="p-1 disabled:opacity-50 hover:bg-gray-100 rounded"
+        title="Move Right"
+      >
+        <MoveRight size={12} />
+      </button>
+    )}
+
+    {/* Remove */}
+    {showRemoveControl && (
+      <button
+        onClick={e => { e.stopPropagation(); onRemove(); }}
+        className="p-1 text-red-600 hover:text-red-800 hover:bg-red-50 rounded"
+        title="Remove Item"
+      >
+        <Trash2 size={12} />
+      </button>
+    )}
+  </div>
+);
+
+export default ItemsControl; 

--- a/src/context/SelectionContext.tsx
+++ b/src/context/SelectionContext.tsx
@@ -39,6 +39,8 @@ interface SelectionContextType {
     blockId: string,
     itemId: string
   ) => void;
+  moveBlockItemLeft: (blockId: string, index: number) => void;
+  moveBlockItemRight: (blockId: string, index: number) => void;
   selectArrayItem: (blockId: string, itemId: string) => void;
   isItemSelected: (blockId: string, itemId: string) => boolean;
 }
@@ -546,6 +548,18 @@ export const SelectionProvider: React.FC<SelectionProviderProps> = ({ children }
     );
   };
 
+  const moveBlockItemLeft = (blockId: string, index: number) => {
+    if (index <= 0) return;
+    modifyBlockItems(blockId, (items) => swap(items, index, index - 1));
+  };
+
+  const moveBlockItemRight = (blockId: string, index: number) => {
+    modifyBlockItems(blockId, (items) => {
+      if (index >= items.length - 1) return items;
+      return swap(items, index, index + 1);
+    });
+  };
+
   const selectArrayItem = (blockId: string, itemId: string): void => {
     setSelectedItemId(itemId);
     setSelectedItemBlockId(blockId);
@@ -577,6 +591,8 @@ export const SelectionProvider: React.FC<SelectionProviderProps> = ({ children }
       addBlockItem,
       updateBlockItem,
       removeBlockItem,
+      moveBlockItemLeft,
+      moveBlockItemRight,
       selectArrayItem,
       isItemSelected
     }}>

--- a/src/context/SelectionContext.tsx
+++ b/src/context/SelectionContext.tsx
@@ -549,15 +549,11 @@ export const SelectionProvider: React.FC<SelectionProviderProps> = ({ children }
   };
 
   const moveBlockItemLeft = (blockId: string, index: number) => {
-    if (index <= 0) return;
     modifyBlockItems(blockId, (items) => swap(items, index, index - 1));
   };
 
   const moveBlockItemRight = (blockId: string, index: number) => {
-    modifyBlockItems(blockId, (items) => {
-      if (index >= items.length - 1) return items;
-      return swap(items, index, index + 1);
-    });
+    modifyBlockItems(blockId, (items) => swap(items, index, index + 1));
   };
 
   const selectArrayItem = (blockId: string, itemId: string): void => {


### PR DESCRIPTION
- Add ItemsControl component with move left/right and delete buttons
- Extend SelectionContext with moveBlockItemLeft/moveBlockItemRight methods
- Integrate ItemsControl into PosterGridWidget for each item
- Enable inline item management with visual controls overlay