### PR TITLE
feat: add button icon support in hero block

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,11 +53,15 @@ const hotstarSchema: PageSchema = {
               textColor: "#ffffff"
             },
             secondaryCTA: {
-              label: "+ Add to Watchlist",
+              label: "Add to Watchlist",
               link: "/watchlist/coolie",
               variant: "outline",
               backgroundColor: "#ffffff",
-              textColor: "#000000"
+              textColor: "#000000",
+              icon: "Plus",
+              iconPosition: "left",
+              iconThickness: "thick",
+              borderRadius: "sm"
             }
           },
           {
@@ -84,11 +88,15 @@ const hotstarSchema: PageSchema = {
               textColor: "#ffffff"
             },
             secondaryCTA: {
-              label: "+ Add to Watchlist",
+              label: "Add to Watchlist",
               link: "/watchlist",
               variant: "outline",
               backgroundColor: "#ffffff",
-              textColor: "#000000"
+              textColor: "#000000",
+              icon: "Plus",
+              iconPosition: "left",
+              iconThickness: "thick",
+              borderRadius: "sm"
             }
           },
           {
@@ -114,11 +122,15 @@ const hotstarSchema: PageSchema = {
               textColor: "#ffffff"
             },
             secondaryCTA: {
-              label: "+ Add to Watchlist",
+              label: "Add to Watchlist",
               link: "/watchlist/leo",
               variant: "outline",
               backgroundColor: "#ffffff",
-              textColor: "#000000"
+              textColor: "#000000",
+              icon: "Plus",
+              iconPosition: "left",
+              iconThickness: "thick",
+              borderRadius: "sm"
             }
           },
           {
@@ -144,11 +156,15 @@ const hotstarSchema: PageSchema = {
               textColor: "#ffffff"
             },
             secondaryCTA: {
-              label: "+ Add to Watchlist",
+              label: "Add to Watchlist",
               link: "/watchlist/vikram",
               variant: "outline",
               backgroundColor: "#ffffff",
-              textColor: "#000000"
+              textColor: "#000000",
+              icon: "Plus",
+              iconPosition: "left",
+              iconThickness: "thick",
+              borderRadius: "sm"
             }
           }
         ]

--- a/src/blocks/hero/ItemWidget.tsx
+++ b/src/blocks/hero/ItemWidget.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { HeroItem } from './schema';
 import VideoPlayer from './VideoPlayer';
+import { ButtonIcon } from './form-components/ButtonIcons';
 
 interface ItemWidgetProps {
   item: HeroItem;
@@ -48,6 +49,18 @@ const ItemWidget: React.FC<ItemWidgetProps> = ({
   };
 
   const aspectRatioClass = getAspectRatioClass(aspectRatio);
+
+  // Helper function to get border radius classes
+  const getBorderRadiusClass = (borderRadius?: string) => {
+    switch (borderRadius) {
+      case 'none': return '';
+      case 'sm': return 'rounded-sm';
+      case 'md': return 'rounded-md';
+      case 'lg': return 'rounded-lg';
+      case 'full': return 'rounded-full';
+      default: return 'rounded-md';
+    }
+  };
 
   return (
     <div 
@@ -135,28 +148,112 @@ const ItemWidget: React.FC<ItemWidgetProps> = ({
           {/* Primary CTA */}
           {item.primaryCTA && (
             <button 
-              className="font-semibold py-2.5 px-6 rounded-lg text-base transition-colors duration-200 border"
+              className={`font-semibold text-base transition-colors duration-200 border flex items-center justify-center gap-2 ${getBorderRadiusClass(item.primaryCTA.borderRadius)} ${
+                item.primaryCTA.borderRadius === 'full' 
+                  ? 'w-12 h-12 p-0' // Circle: fixed square dimensions with no padding
+                  : 'py-2.5 px-6'    // Regular: normal padding
+              }`}
               style={{
                 backgroundColor: item.primaryCTA.backgroundColor || '#dc2626',
                 color: item.primaryCTA.textColor || '#ffffff',
                 borderColor: item.primaryCTA.variant === 'outline' ? item.primaryCTA.textColor || '#ffffff' : 'transparent'
               }}
             >
-              {item.primaryCTA.label}
+              {item.primaryCTA.borderRadius === 'full' ? (
+                // Circle button: only show icon, no text
+                item.primaryCTA.icon && item.primaryCTA.icon !== 'None' ? (
+                  <ButtonIcon 
+                    icon={item.primaryCTA.icon} 
+                    size={20} 
+                    thickness={item.primaryCTA.iconThickness}
+                  />
+                ) : (
+                  // If no icon, show first letter of label
+                  <span className="text-lg font-bold">
+                    {item.primaryCTA.label.charAt(0).toUpperCase()}
+                  </span>
+                )
+              ) : (
+                // Regular button: show icon + text
+                <>
+                  {/* Left Icon */}
+                  {item.primaryCTA.icon && item.primaryCTA.icon !== 'None' && item.primaryCTA.iconPosition === 'left' && (
+                    <ButtonIcon 
+                      icon={item.primaryCTA.icon} 
+                      size={20} 
+                      thickness={item.primaryCTA.iconThickness}
+                    />
+                  )}
+                  
+                  {/* Label */}
+                  <span>{item.primaryCTA.label}</span>
+                  
+                  {/* Right Icon */}
+                  {item.primaryCTA.icon && item.primaryCTA.icon !== 'None' && item.primaryCTA.iconPosition === 'right' && (
+                    <ButtonIcon 
+                      icon={item.primaryCTA.icon} 
+                      size={20} 
+                      thickness={item.primaryCTA.iconThickness}
+                    />
+                  )}
+                </>
+              )}
             </button>
           )}
           
           {/* Secondary CTA */}
           {item.secondaryCTA && (
             <button 
-              className="font-semibold py-2.5 px-5 rounded-lg text-base transition-colors duration-200 border"
+              className={`font-semibold text-base transition-colors duration-200 border flex items-center justify-center gap-2 ${getBorderRadiusClass(item.secondaryCTA.borderRadius)} ${
+                item.secondaryCTA.borderRadius === 'full' 
+                  ? 'w-12 h-12 p-0' // Circle: fixed square dimensions with no padding
+                  : 'py-2.5 px-5'    // Regular: normal padding
+              }`}
               style={{
                 backgroundColor: item.secondaryCTA.backgroundColor || '#ffffff',
                 color: item.secondaryCTA.textColor || '#000000',
                 borderColor: item.secondaryCTA.variant === 'outline' ? item.secondaryCTA.textColor || '#000000' : 'transparent'
               }}
             >
-              {item.secondaryCTA.label}
+              {item.secondaryCTA.borderRadius === 'full' ? (
+                // Circle button: only show icon, no text
+                item.secondaryCTA.icon && item.secondaryCTA.icon !== 'None' ? (
+                  <ButtonIcon 
+                    icon={item.secondaryCTA.icon} 
+                    size={20} 
+                    thickness={item.secondaryCTA.iconThickness}
+                  />
+                ) : (
+                  // If no icon, show first letter of label
+                  <span className="text-lg font-bold">
+                    {item.secondaryCTA.label.charAt(0).toUpperCase()}
+                  </span>
+                )
+              ) : (
+                // Regular button: show icon + text
+                <>
+                  {/* Left Icon */}
+                  {item.secondaryCTA.icon && item.secondaryCTA.icon !== 'None' && item.secondaryCTA.iconPosition === 'left' && (
+                    <ButtonIcon 
+                      icon={item.secondaryCTA.icon} 
+                      size={20} 
+                      thickness={item.secondaryCTA.iconThickness}
+                    />
+                  )}
+                  
+                  {/* Label */}
+                  <span>{item.secondaryCTA.label}</span>
+                  
+                  {/* Right Icon */}
+                  {item.secondaryCTA.icon && item.secondaryCTA.icon !== 'None' && item.secondaryCTA.iconPosition === 'right' && (
+                    <ButtonIcon 
+                      icon={item.secondaryCTA.icon} 
+                      size={20} 
+                      thickness={item.secondaryCTA.iconThickness}
+                    />
+                  )}
+                </>
+              )}
             </button>
           )}
         </div>

--- a/src/blocks/hero/form-components/ButtonIcons.tsx
+++ b/src/blocks/hero/form-components/ButtonIcons.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Play, Plus, Info, ChevronRight, ChevronLeft, ArrowRight, ArrowLeft, Download } from 'lucide-react';
+
+export type ButtonIconType = 
+  | 'Play' 
+  | 'Plus' 
+  | 'Info' 
+  | 'ChevronRight' 
+  | 'ChevronLeft' 
+  | 'ArrowRight' 
+  | 'ArrowLeft' 
+  | 'Download'
+  | 'None';
+
+interface ButtonIconProps {
+  icon: ButtonIconType;
+  size?: number;
+  thickness?: 'thin' | 'normal' | 'thick';
+}
+
+export const ButtonIcon: React.FC<ButtonIconProps> = ({ icon, size = 16, thickness = 'normal' }) => {
+  // Map thickness to stroke width with more noticeable differences
+  const strokeWidth = thickness === 'thin' ? 1 : thickness === 'thick' ? 3 : 2;
+  
+  switch (icon) {
+    case 'Play':
+      return <Play size={size} strokeWidth={strokeWidth} />;
+    case 'Plus':
+      return <Plus size={size} strokeWidth={strokeWidth} />;
+    case 'Info':
+      return <Info size={size} strokeWidth={strokeWidth} />;
+    case 'ChevronRight':
+      return <ChevronRight size={size} strokeWidth={strokeWidth} />;
+    case 'ChevronLeft':
+      return <ChevronLeft size={size} strokeWidth={strokeWidth} />;
+    case 'ArrowRight':
+      return <ArrowRight size={size} strokeWidth={strokeWidth} />;
+    case 'ArrowLeft':
+      return <ArrowLeft size={size} strokeWidth={strokeWidth} />;
+    case 'Download':
+      return <Download size={size} strokeWidth={strokeWidth} />;
+    case 'None':
+    default:
+      return null;
+  }
+};
+
+// Define icon position type
+export type ButtonIconPosition = 'left' | 'right' | 'none';
+
+// Export all available icons for the preview panel
+export const AVAILABLE_ICONS = [
+  { type: 'Play', label: 'Play' },
+  { type: 'Plus', label: 'Plus' },
+  { type: 'Info', label: 'Info' },
+  { type: 'ChevronRight', label: 'Chevron Right' },
+  { type: 'ChevronLeft', label: 'Chevron Left' },
+  { type: 'ArrowRight', label: 'Arrow Right' },
+  { type: 'ArrowLeft', label: 'Arrow Left' },
+  { type: 'Download', label: 'Download' },
+  { type: 'None', label: 'No Icon' }
+];

--- a/src/blocks/hero/form-components/CTAsTab.tsx
+++ b/src/blocks/hero/form-components/CTAsTab.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import type { HeroItem, HeroCTABtn } from '../schema';
+import { ButtonIcon, AVAILABLE_ICONS } from './ButtonIcons';
+import type { ButtonIconPosition } from './ButtonIcons';
 
 interface CTAsTabProps {
   currentItem: HeroItem;
@@ -18,11 +20,15 @@ const CTAsTab: React.FC<CTAsTabProps> = ({
   const handlePrimaryCTAChange = (field: keyof HeroCTABtn, value: any) => {
     const newCTA = {
       ...(currentItem.primaryCTA || {}),
-      label: currentItem.primaryCTA?.label || 'CTA',
-      link: currentItem.primaryCTA?.link || '#',
-      variant: currentItem.primaryCTA?.variant || 'solid',
-      backgroundColor: currentItem.primaryCTA?.backgroundColor || '#dc2626',
-      textColor: currentItem.primaryCTA?.textColor || '#ffffff',
+      label: currentItem.primaryCTA?.label ?? 'CTA',
+      link: currentItem.primaryCTA?.link ?? '#',
+      variant: currentItem.primaryCTA?.variant ?? 'solid',
+      backgroundColor: currentItem.primaryCTA?.backgroundColor ?? '#dc2626',
+      textColor: currentItem.primaryCTA?.textColor ?? '#ffffff',
+      icon: currentItem.primaryCTA?.icon ?? 'None',
+      iconPosition: currentItem.primaryCTA?.iconPosition ?? 'left',
+      iconThickness: currentItem.primaryCTA?.iconThickness ?? 'normal',
+      borderRadius: currentItem.primaryCTA?.borderRadius ?? 'md',
       [field]: value
     };
     updateHeroItemPrimaryCTA(newCTA as HeroCTABtn);
@@ -34,6 +40,10 @@ const CTAsTab: React.FC<CTAsTabProps> = ({
     
     const newCTA = {
       ...secondaryCTA,
+      icon: secondaryCTA.icon ?? 'None',
+      iconPosition: secondaryCTA.iconPosition ?? 'left',
+      iconThickness: secondaryCTA.iconThickness ?? 'normal',
+      borderRadius: secondaryCTA.borderRadius ?? 'md',
       [field]: value
     };
     updateHeroItemSecondaryCTA(newCTA);
@@ -45,7 +55,11 @@ const CTAsTab: React.FC<CTAsTabProps> = ({
       link: '#', 
       variant: 'outline' as const, 
       backgroundColor: '#ffffff', 
-      textColor: '#000000' 
+      textColor: '#000000',
+      icon: 'None' as const,
+      iconPosition: 'right' as const,
+      iconThickness: 'normal' as const,
+      borderRadius: 'md' as const
     };
     updateHeroItemSecondaryCTA(newCTA);
   };
@@ -63,24 +77,24 @@ const CTAsTab: React.FC<CTAsTabProps> = ({
         <div className="space-y-2">
           <div>
             <label className="block text-xs text-gray-600 mb-1">Label</label>
-            <input
-              type="text"
-              value={currentItem.primaryCTA?.label || ''}
-              onChange={(e) => handlePrimaryCTAChange('label', e.target.value)}
-              className="w-full p-2 border border-gray-300 rounded"
-              placeholder="Enter CTA text..."
-            />
+         <input
+                type="text"
+                value={currentItem.primaryCTA?.label ?? ''}
+                onChange={(e) => handlePrimaryCTAChange('label', e.target.value)}
+                className="w-full p-2 border border-gray-300 rounded"
+                placeholder="Enter CTA text..."
+              />
           </div>
           
           <div>
             <label className="block text-xs text-gray-600 mb-1">Link</label>
-            <input
-              type="text"
-              value={currentItem.primaryCTA?.link || ''}
-              onChange={(e) => handlePrimaryCTAChange('link', e.target.value)}
-              className="w-full p-2 border border-gray-300 rounded"
-              placeholder="Enter CTA link..."
-            />
+              <input
+                type="text"
+                value={currentItem.primaryCTA?.link ?? ''}
+                onChange={(e) => handlePrimaryCTAChange('link', e.target.value)}
+                className="w-full p-2 border border-gray-300 rounded"
+                placeholder="Enter CTA link..."
+              />
           </div>
           
           <div>
@@ -113,6 +127,75 @@ const CTAsTab: React.FC<CTAsTabProps> = ({
               onChange={(e) => handlePrimaryCTAChange('textColor', e.target.value)}
               className="w-full h-10 border border-gray-300 rounded"
             />
+          </div>
+          
+          {/* Icon Selection */}
+          <div>
+            <label className="block text-xs text-gray-600 mb-1">Button Icon</label>
+            <select
+              value={currentItem.primaryCTA?.icon ?? 'None'}
+              onChange={(e) => handlePrimaryCTAChange('icon', e.target.value)}
+              className="w-full p-2 border border-gray-300 rounded"
+            >
+              {AVAILABLE_ICONS.map(icon => (
+                <option key={icon.type} value={icon.type}>{icon.label}</option>
+              ))}
+            </select>
+            
+                            {/* Icon Preview */}
+                {currentItem.primaryCTA?.icon && currentItem.primaryCTA.icon !== 'None' && (
+                  <div className="mt-2 p-2 bg-gray-100 rounded flex items-center gap-2">
+                    <ButtonIcon icon={currentItem.primaryCTA.icon} />
+                    <span className="text-xs">{currentItem.primaryCTA.icon}</span>
+                  </div>
+                )}
+          </div>
+          
+          {/* Icon Position - only show if an icon is selected */}
+          {currentItem.primaryCTA?.icon && currentItem.primaryCTA.icon !== 'None' && (
+            <div>
+              <label className="block text-xs text-gray-600 mb-1">Icon Position</label>
+              <select
+                value={currentItem.primaryCTA?.iconPosition ?? 'left'}
+                onChange={(e) => handlePrimaryCTAChange('iconPosition', e.target.value as ButtonIconPosition)}
+                className="w-full p-2 border border-gray-300 rounded"
+              >
+                <option value="left">Left</option>
+                <option value="right">Right</option>
+              </select>
+            </div>
+          )}
+          
+          {/* Icon Thickness - only show if an icon is selected */}
+          {currentItem.primaryCTA?.icon && currentItem.primaryCTA.icon !== 'None' && (
+            <div>
+              <label className="block text-xs text-gray-600 mb-1">Icon Thickness</label>
+              <select
+                value={currentItem.primaryCTA?.iconThickness ?? 'normal'}
+                onChange={(e) => handlePrimaryCTAChange('iconThickness', e.target.value as 'thin' | 'normal' | 'thick')}
+                className="w-full p-2 border border-gray-300 rounded"
+              >
+                <option value="thin">Thin</option>
+                <option value="normal">Normal</option>
+                <option value="thick">Thick</option>
+              </select>
+            </div>
+          )}
+          
+          {/* Border Radius */}
+          <div>
+            <label className="block text-xs text-gray-600 mb-1">Border Radius</label>
+            <select
+              value={currentItem.primaryCTA?.borderRadius ?? 'md'}
+              onChange={(e) => handlePrimaryCTAChange('borderRadius', e.target.value as 'none' | 'sm' | 'md' | 'lg' | 'full')}
+              className="w-full p-2 border border-gray-300 rounded"
+            >
+              <option value="none">None</option>
+              <option value="sm">Small</option>
+              <option value="md">Medium</option>
+              <option value="lg">Large</option>
+              <option value="full">Full (Circle)</option>
+            </select>
           </div>
         </div>
       </div>
@@ -155,7 +238,7 @@ const CTAsTab: React.FC<CTAsTabProps> = ({
                 <label className="block text-xs text-gray-600 mb-1">Label</label>
                 <input
                   type="text"
-                  value={secondaryCTA.label || ''}
+                  value={secondaryCTA.label ?? ''}
                   onChange={(e) => handleSecondaryCTAChange('label', e.target.value)}
                   className="w-full p-2 border border-gray-300 rounded"
                   placeholder="Enter CTA text..."
@@ -166,7 +249,7 @@ const CTAsTab: React.FC<CTAsTabProps> = ({
                 <label className="block text-xs text-gray-600 mb-1">Link</label>
                 <input
                   type="text"
-                  value={secondaryCTA.link || ''}
+                  value={secondaryCTA.link ?? ''}
                   onChange={(e) => handleSecondaryCTAChange('link', e.target.value)}
                   className="w-full p-2 border border-gray-300 rounded"
                   placeholder="Enter CTA link..."
@@ -203,6 +286,75 @@ const CTAsTab: React.FC<CTAsTabProps> = ({
                   onChange={(e) => handleSecondaryCTAChange('textColor', e.target.value)}
                   className="w-full h-10 border border-gray-300 rounded"
                 />
+              </div>
+              
+              {/* Icon Selection */}
+              <div>
+                <label className="block text-xs text-gray-600 mb-1">Button Icon</label>
+                <select
+                  value={secondaryCTA.icon ?? 'None'}
+                  onChange={(e) => handleSecondaryCTAChange('icon', e.target.value)}
+                  className="w-full p-2 border border-gray-300 rounded"
+                >
+                  {AVAILABLE_ICONS.map(icon => (
+                    <option key={icon.type} value={icon.type}>{icon.label}</option>
+                  ))}
+                </select>
+                
+                {/* Icon Preview */}
+                {secondaryCTA.icon && secondaryCTA.icon !== 'None' && (
+                  <div className="mt-2 p-2 bg-gray-100 rounded flex items-center gap-2">
+                    <ButtonIcon icon={secondaryCTA.icon} />
+                    <span className="text-xs">{secondaryCTA.icon}</span>
+                  </div>
+                )}
+              </div>
+              
+                            {/* Icon Position - only show if an icon is selected */}
+              {secondaryCTA.icon && secondaryCTA.icon !== 'None' && (
+                <div>
+                  <label className="block text-xs text-gray-600 mb-1">Icon Position</label>
+                  <select
+                    value={secondaryCTA.iconPosition ?? 'left'}
+                    onChange={(e) => handleSecondaryCTAChange('iconPosition', e.target.value as ButtonIconPosition)}
+                    className="w-full p-2 border border-gray-300 rounded"
+                  >
+                    <option value="left">Left</option>
+                    <option value="right">Right</option>
+                  </select>
+                </div>
+              )}
+              
+              {/* Icon Thickness - only show if an icon is selected */}
+              {secondaryCTA.icon && secondaryCTA.icon !== 'None' && (
+                <div>
+                  <label className="block text-xs text-gray-600 mb-1">Icon Thickness</label>
+                  <select
+                    value={secondaryCTA.iconThickness ?? 'normal'}
+                    onChange={(e) => handleSecondaryCTAChange('iconThickness', e.target.value as 'thin' | 'normal' | 'thick')}
+                    className="w-full p-2 border border-gray-300 rounded"
+                  >
+                    <option value="thin">Thin</option>
+                    <option value="normal">Normal</option>
+                    <option value="thick">Thick</option>
+                  </select>
+                </div>
+              )}
+              
+              {/* Border Radius */}
+              <div>
+                <label className="block text-xs text-gray-600 mb-1">Border Radius</label>
+                <select
+                  value={secondaryCTA.borderRadius ?? 'md'}
+                  onChange={(e) => handleSecondaryCTAChange('borderRadius', e.target.value as 'none' | 'sm' | 'md' | 'lg' | 'full')}
+                  className="w-full p-2 border border-gray-300 rounded"
+                >
+                  <option value="none">None</option>
+                  <option value="sm">Small</option>
+                  <option value="md">Medium</option>
+                  <option value="lg">Large</option>
+                  <option value="full">Full (Circle)</option>
+                </select>
               </div>
             </div>
           </div>

--- a/src/blocks/hero/libraryItem.ts
+++ b/src/blocks/hero/libraryItem.ts
@@ -24,12 +24,20 @@ export const HeroLibraryItem = {
         primaryCTA: { 
           label: 'Watch Now', 
           link: '/watch',
-          variant: 'solid'
+          variant: 'solid',
+          icon: 'Play',
+          iconPosition: 'left',
+          iconThickness: 'normal',
+          borderRadius: 'md'
         },
         secondaryCTA: { 
           label: 'Trailer', 
           link: '/trailer',
-          variant: 'outline'
+          variant: 'outline',
+          icon: 'Info',
+          iconPosition: 'right',
+          iconThickness: 'normal',
+          borderRadius: 'md'
         },
         metadata: { 
           year: '2025', 

--- a/src/blocks/hero/schema.ts
+++ b/src/blocks/hero/schema.ts
@@ -34,7 +34,10 @@ export interface HeroCTABtn {
   variant?: 'solid' | 'outline';
   backgroundColor?: string;
   textColor?: string;
-  icon?: string;
+  icon?: 'Play' | 'Plus' | 'Info' | 'ChevronRight' | 'ChevronLeft' | 'ArrowRight' | 'ArrowLeft' | 'Download' | 'None';
+  iconPosition?: 'left' | 'right';
+  borderRadius?: 'none' | 'sm' | 'md' | 'lg' | 'full';
+  iconThickness?: 'thin' | 'normal' | 'thick';
 }
 
 export interface HeroMetadata {


### PR DESCRIPTION
- Add ButtonIcons component with 8 icon types (Play, Plus, Info, Chevron, Arrow, Download)
- Support left/right icon positioning with configurable thickness (thin/normal/thick)
- Add icon selection controls to the CTA buttons form
- Update hero block schema to include icon properties
- Enhance ItemWidget to render buttons with icons
- Update sample data to showcase new icon functionality