### PR TITLE
feat: add page schema switching functionality

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import { LibraryPanelProvider } from '@context/LibraryPanelContext';
 import { SettingsPanelProvider } from '@context/SettingsPanelContext';
 import { PageSchemaProvider } from '@context/PageSchemaContext';
 import { useState } from 'react';
-import netflixSchemaData from './pageSchemas/netflixSchema.json';
+import netflixSchemaData from '@pageSchemas/netflixSchema.json';
 import type { PageSchema } from '@blocks/shared/Page';
 
 function App() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,49 +1,46 @@
 import Canvas from '@layout/Canvas';
 import SettingsPanel from '@layout/SettingsPanel';
 import TopBar from '@layout/TopBar';
-import type { PageSchema } from '@blocks/shared/Page';
 import LibraryPanel from '@layout/LibraryPanel';
 import { SelectionProvider } from '@context/SelectionContext';
 import { HistoryProvider } from '@context/HistoryContext';
 import { BlockInsertProvider } from '@context/BlockInsertContext';
 import { LibraryPanelProvider } from '@context/LibraryPanelContext';
 import { SettingsPanelProvider } from '@context/SettingsPanelContext';
+import { PageSchemaProvider } from '@context/PageSchemaContext';
 import { useState } from 'react';
 import netflixSchemaData from './pageSchemas/netflixSchema.json';
-import hotstarSchemaData from './pageSchemas/hotstarSchema.json';
-
-// Use the imported Hotstar schema
-const hotstarSchema: PageSchema = hotstarSchemaData as PageSchema;
-
-const netflixSchema: PageSchema = netflixSchemaData as PageSchema;
+import type { PageSchema } from '@blocks/shared/Page';
 
 function App() {
   const [showDebug, setShowDebug] = useState(false);
 
   return (
-    <HistoryProvider initialSchema={netflixSchema}>
-      <SelectionProvider>
-        <BlockInsertProvider>
-          <LibraryPanelProvider>
-            <SettingsPanelProvider>
-              <div className="min-h-screen flex flex-col bg-black">
-                <TopBar />
-                <div className="flex-1 flex pt-16 min-h-0">
-                  <LibraryPanel />
-                  <div className="flex-1 min-w-0">
-                    <Canvas showDebug={showDebug} />
+    <PageSchemaProvider>
+      <HistoryProvider initialSchema={netflixSchemaData as PageSchema}>
+        <SelectionProvider>
+          <BlockInsertProvider>
+            <LibraryPanelProvider>
+              <SettingsPanelProvider>
+                <div className="min-h-screen flex flex-col bg-black">
+                  <TopBar />
+                  <div className="flex-1 flex pt-16 min-h-0">
+                    <LibraryPanel />
+                    <div className="flex-1 min-w-0">
+                      <Canvas showDebug={showDebug} />
+                    </div>
+                    <SettingsPanel 
+                      showDebug={showDebug}
+                      onToggleShowDebug={() => setShowDebug(current => !current)}
+                    />
                   </div>
-                  <SettingsPanel 
-                    showDebug={showDebug}
-                    onToggleShowDebug={() => setShowDebug(current => !current)}
-                  />
                 </div>
-              </div>
-            </SettingsPanelProvider>
-          </LibraryPanelProvider>
-        </BlockInsertProvider>
-      </SelectionProvider>
-    </HistoryProvider>
+              </SettingsPanelProvider>
+            </LibraryPanelProvider>
+          </BlockInsertProvider>
+        </SelectionProvider>
+      </HistoryProvider>
+    </PageSchemaProvider>
   );
 }
 

--- a/src/context/HistoryContext.tsx
+++ b/src/context/HistoryContext.tsx
@@ -4,7 +4,8 @@ import type { PageSchema } from '@blocks/shared/Page';
 
 interface HistoryContextType {
   pageSchema: PageSchema;
-  updatePageWithHistory: (schema: PageSchema) => void;
+  updatePageWithHistory: (pageSchema: PageSchema) => void;
+  updatePageSchema: (pageSchema: PageSchema) => void;
   undo: () => void;
   canUndo: boolean;
   redo: () => void;
@@ -44,6 +45,14 @@ export const HistoryProvider: React.FC<HistoryProviderProps> = ({ children, init
     setPageSchema(newSchema);
   };
 
+  // Public function to update page schema without history recording (for page schema switching)
+  const updatePageSchema = (newPageSchema: PageSchema) => {
+    setPageSchema(newPageSchema);
+    // Clear history when switching page schemas
+    setUndoStack([]);
+    setRedoStack([]);
+  };
+
   const undo = () => {
     if (undoStack.length === 0) return;
     
@@ -76,6 +85,7 @@ export const HistoryProvider: React.FC<HistoryProviderProps> = ({ children, init
     <HistoryContext.Provider value={{
       pageSchema,
       updatePageWithHistory,
+      updatePageSchema,
       undo,
       canUndo,
       redo,

--- a/src/context/PageSchemaContext.tsx
+++ b/src/context/PageSchemaContext.tsx
@@ -1,8 +1,7 @@
 import React, { createContext, useContext, useState, type ReactNode } from 'react';
 import type { PageSchema } from '@blocks/shared/Page';
-import netflixSchemaData from '../pageSchemas/netflixSchema.json';
-import hotstarSchemaData from '../pageSchemas/hotstarSchema.json';
-import { useHistory } from './HistoryContext';
+import netflixSchemaData from '@pageSchemas/netflixSchema.json';
+import hotstarSchemaData from '@pageSchemas/hotstarSchema.json';
 
 // Define available page schemas
 export const availablePageSchemas = {
@@ -50,22 +49,6 @@ export const PageSchemaProvider: React.FC<PageSchemaProviderProps> = ({
   );
 };
 
-// Hook to use page schema with history integration
-export const usePageSchemaWithHistory = () => {
-  const { currentPageSchemaKey, setCurrentPageSchemaKey } = usePageSchema();
-  const { updatePageSchema } = useHistory();
-  
-  const switchPageSchema = (pageSchemaKey: PageSchemaKey) => {
-    const newPageSchema = availablePageSchemas[pageSchemaKey].pageSchema;
-    setCurrentPageSchemaKey(pageSchemaKey);
-    updatePageSchema(newPageSchema);
-  };
-  
-  return {
-    currentPageSchemaKey,
-    switchPageSchema
-  };
-};
 
 export const usePageSchema = (): PageSchemaContextType => {
   const context = useContext(PageSchemaContext);

--- a/src/context/PageSchemaContext.tsx
+++ b/src/context/PageSchemaContext.tsx
@@ -1,0 +1,76 @@
+import React, { createContext, useContext, useState, type ReactNode } from 'react';
+import type { PageSchema } from '@blocks/shared/Page';
+import netflixSchemaData from '../pageSchemas/netflixSchema.json';
+import hotstarSchemaData from '../pageSchemas/hotstarSchema.json';
+import { useHistory } from './HistoryContext';
+
+// Define available page schemas
+export const availablePageSchemas = {
+  netflix: {
+    name: 'Netflix Page',
+    pageSchema: netflixSchemaData as PageSchema
+  },
+  hotstar: {
+    name: 'Hotstar Page',
+    pageSchema: hotstarSchemaData as PageSchema
+  }
+};
+
+export type PageSchemaKey = keyof typeof availablePageSchemas;
+
+interface PageSchemaContextType {
+  currentPageSchemaKey: PageSchemaKey;
+  currentPageSchema: PageSchema;
+  setCurrentPageSchemaKey: (key: PageSchemaKey) => void;
+}
+
+const PageSchemaContext = createContext<PageSchemaContextType | undefined>(undefined);
+
+interface PageSchemaProviderProps {
+  children: ReactNode;
+  initialPageSchemaKey?: PageSchemaKey;
+}
+
+export const PageSchemaProvider: React.FC<PageSchemaProviderProps> = ({ 
+  children, 
+  initialPageSchemaKey = 'netflix' 
+}) => {
+  const [currentPageSchemaKey, setCurrentPageSchemaKey] = useState<PageSchemaKey>(initialPageSchemaKey);
+
+  const currentPageSchema = availablePageSchemas[currentPageSchemaKey].pageSchema;
+
+  return (
+    <PageSchemaContext.Provider value={{
+      currentPageSchemaKey,
+      currentPageSchema,
+      setCurrentPageSchemaKey
+    }}>
+      {children}
+    </PageSchemaContext.Provider>
+  );
+};
+
+// Hook to use page schema with history integration
+export const usePageSchemaWithHistory = () => {
+  const { currentPageSchemaKey, setCurrentPageSchemaKey } = usePageSchema();
+  const { updatePageSchema } = useHistory();
+  
+  const switchPageSchema = (pageSchemaKey: PageSchemaKey) => {
+    const newPageSchema = availablePageSchemas[pageSchemaKey].pageSchema;
+    setCurrentPageSchemaKey(pageSchemaKey);
+    updatePageSchema(newPageSchema);
+  };
+  
+  return {
+    currentPageSchemaKey,
+    switchPageSchema
+  };
+};
+
+export const usePageSchema = (): PageSchemaContextType => {
+  const context = useContext(PageSchemaContext);
+  if (context === undefined) {
+    throw new Error('usePageSchema must be used within a PageSchemaProvider');
+  }
+  return context;
+};

--- a/src/hooks/useOnClickOutside.ts
+++ b/src/hooks/useOnClickOutside.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import type { RefObject } from 'react';
+
+type Event = MouseEvent | TouchEvent;
+
+export const useOnClickOutside = <T extends HTMLElement = HTMLElement>(
+  ref: RefObject<T | null>,
+  handler: (event: Event) => void
+) => {
+  useEffect(() => {
+    const listener = (event: Event) => {
+      const el = ref?.current;
+      // Do nothing if clicking ref's element or descendent elements
+      if (!el || el.contains(event.target as Node)) {
+        return;
+      }
+      handler(event);
+    };
+
+    document.addEventListener('mousedown', listener);
+    document.addEventListener('touchstart', listener);
+
+    return () => {
+      document.removeEventListener('mousedown', listener);
+      document.removeEventListener('touchstart', listener);
+    };
+  }, [ref, handler]); // Reload only if ref or handler changes
+};

--- a/src/layout/SettingsPanel.tsx
+++ b/src/layout/SettingsPanel.tsx
@@ -333,28 +333,6 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ showDebug, onToggleShowDe
               blockType={selectedBlock.type}
             />
           )}
-          
-          <div>
-            <h2 className="text-lg font-semibold text-gray-800 mb-4">Page Settings</h2>
-            <div className="space-y-4">
-              <div className="p-4 bg-gray-50 rounded-lg">
-                <h3 className="font-medium text-gray-700 mb-2">Page Title</h3>
-                <input 
-                  type="text" 
-                  placeholder="Enter page title"
-                  className="w-full p-2 border border-gray-300 rounded text-sm"
-                />
-              </div>
-              
-              <div className="p-4 bg-gray-50 rounded-lg">
-                <h3 className="font-medium text-gray-700 mb-2">Meta Description</h3>
-                <textarea 
-                  placeholder="Enter meta description"
-                  className="w-full p-2 border border-gray-300 rounded text-sm h-20"
-                />
-              </div>
-            </div>
-          </div>
         </div>
       </div>
     </div>

--- a/src/layout/TopBar.tsx
+++ b/src/layout/TopBar.tsx
@@ -4,34 +4,26 @@ import { useHistory } from '@context/HistoryContext';
 import { useLibraryPanel } from '@context/LibraryPanelContext';
 import { useSettingsPanel } from '@context/SettingsPanelContext';
 import { useSelection } from '@context/SelectionContext';
-import { usePageSchemaWithHistory, availablePageSchemas, type PageSchemaKey } from '@context/PageSchemaContext';
+import { usePageSchema, availablePageSchemas, type PageSchemaKey } from '@context/PageSchemaContext';
+import { useOnClickOutside } from '@hooks/useOnClickOutside';
 
 const TopBar: React.FC = () => {
-  const { undo, canUndo, redo, canRedo } = useHistory();
+  const { undo, canUndo, redo, canRedo, updatePageSchema } = useHistory();
   const { isLibraryOpen, toggleLibrary } = useLibraryPanel();
   const { isSettingsOpen, toggleSettings } = useSettingsPanel();
   const { setSelectedBlock, setSelectedBlockId, setSelectedItemId, setSelectedItemBlockId } = useSelection();
-  const { currentPageSchemaKey, switchPageSchema } = usePageSchemaWithHistory();
+  const { currentPageSchemaKey, setCurrentPageSchemaKey } = usePageSchema();
   
   const [isPageSchemaDropdownOpen, setIsPageSchemaDropdownOpen] = React.useState(false);
   const dropdownRef = React.useRef<HTMLDivElement>(null);
   
-  // Handle click outside to close dropdown
-  React.useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setIsPageSchemaDropdownOpen(false);
-      }
-    };
-    
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, []);
+  useOnClickOutside(dropdownRef, () => setIsPageSchemaDropdownOpen(false));
   
   const handlePageSchemaChange = (pageSchemaKey: PageSchemaKey) => {
-    switchPageSchema(pageSchemaKey);
+    // This logic is moved from the hook - orchestrating both contexts
+    const newPageSchema = availablePageSchemas[pageSchemaKey].pageSchema;
+    setCurrentPageSchemaKey(pageSchemaKey);
+    updatePageSchema(newPageSchema);
     setIsPageSchemaDropdownOpen(false);
   };
 

--- a/src/layout/TopBar.tsx
+++ b/src/layout/TopBar.tsx
@@ -1,15 +1,39 @@
 import React from 'react';
-import { Undo, Redo, Plus, X, SlidersHorizontal } from 'lucide-react';
+import { Undo, Redo, Plus, X, SlidersHorizontal, ChevronDown } from 'lucide-react';
 import { useHistory } from '@context/HistoryContext';
 import { useLibraryPanel } from '@context/LibraryPanelContext';
 import { useSettingsPanel } from '@context/SettingsPanelContext';
 import { useSelection } from '@context/SelectionContext';
+import { usePageSchemaWithHistory, availablePageSchemas, type PageSchemaKey } from '@context/PageSchemaContext';
 
 const TopBar: React.FC = () => {
   const { undo, canUndo, redo, canRedo } = useHistory();
   const { isLibraryOpen, toggleLibrary } = useLibraryPanel();
   const { isSettingsOpen, toggleSettings } = useSettingsPanel();
   const { setSelectedBlock, setSelectedBlockId, setSelectedItemId, setSelectedItemBlockId } = useSelection();
+  const { currentPageSchemaKey, switchPageSchema } = usePageSchemaWithHistory();
+  
+  const [isPageSchemaDropdownOpen, setIsPageSchemaDropdownOpen] = React.useState(false);
+  const dropdownRef = React.useRef<HTMLDivElement>(null);
+  
+  // Handle click outside to close dropdown
+  React.useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsPageSchemaDropdownOpen(false);
+      }
+    };
+    
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+  
+  const handlePageSchemaChange = (pageSchemaKey: PageSchemaKey) => {
+    switchPageSchema(pageSchemaKey);
+    setIsPageSchemaDropdownOpen(false);
+  };
 
   const handleSettingsToggle = () => {
     if (isSettingsOpen) {
@@ -26,6 +50,34 @@ const TopBar: React.FC = () => {
       <div className="flex items-center justify-between">
         <div className="flex items-center space-x-3">
           <h1 className="text-xl font-bold">Flimix Studio</h1>
+          
+          {/* Page Schema Selector - Choose between Netflix and Hotstar page layouts */}
+          <div className="relative" ref={dropdownRef}>
+            <button
+              onClick={() => setIsPageSchemaDropdownOpen(!isPageSchemaDropdownOpen)}
+              className="px-3 py-2 bg-gray-700 hover:bg-gray-600 rounded flex items-center space-x-2"
+            >
+              <span>{availablePageSchemas[currentPageSchemaKey].name}</span>
+              <ChevronDown size={16} className={`transition-transform ${isPageSchemaDropdownOpen ? 'rotate-180' : ''}`} />
+            </button>
+            
+            {isPageSchemaDropdownOpen && (
+              <div className="absolute top-full left-0 mt-1 bg-gray-700 rounded shadow-lg w-48 z-50">
+                {Object.entries(availablePageSchemas).map(([key, { name }]) => (
+                  <button
+                    key={key}
+                    onClick={() => handlePageSchemaChange(key as PageSchemaKey)}
+                    className={`w-full text-left px-4 py-2 hover:bg-gray-600 ${
+                      currentPageSchemaKey === key ? 'bg-blue-600' : ''
+                    }`}
+                  >
+                    {name}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+          
           <button 
             onClick={toggleLibrary}
             className="w-8 h-8 rounded-full flex items-center justify-center bg-blue-500 text-white hover:bg-blue-600 transition-all duration-200"

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -37,6 +37,8 @@
       "@utils/*": ["src/utils/*"],
       "@domain/*": ["src/domain/*"],
       "@context/*": ["src/context/*"],
+      "@pageSchemas/*": ["src/pageSchemas/*"],
+      "@hooks/*": ["src/hooks/*"],
       "@types/*": ["src/types/*"]
     }
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,8 @@ export default defineConfig({
       '@utils': '/src/utils',
       '@domain': '/src/domain',
       '@types': '/src/types',
+      '@pageSchemas': '/src/pageSchemas',
+      '@hooks': '/src/hooks',
       '@blocks': '/src/blocks',
       '@blocks/ui': '/src/blocks/ui',
       '@blocks/settings': '/src/blocks/settings',


### PR DESCRIPTION
- Create new PageSchemaContext for managing multiple page schemas
- Add page schema dropdown selector in TopBar with Netflix/Hotstar options
- Integrate page schema switching with history management
- Remove hardcoded page schema from App.tsx and make it dynamic
- Add updatePageSchema function to HistoryContext for schema switching
- Remove static page settings section from SettingsPanel
- Implement click-outside handling for dropdown menu
- Support switching between Netflix and Hotstar page layouts seamlessly