### PR TITLE
feat: add page save functionality with Django API integration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { LayoutPanelProvider } from '@context/LayoutPanelContext';
 import { SettingsPanelProvider } from '@context/SettingsPanelContext';
 import { PageSchemaProvider } from '@context/PageSchemaContext';
 import { PanelCoordinatorProvider } from '@context/PanelCoordinator';
+import { SavePageProvider } from '@context/SavePageContext';
 import { useState } from 'react';
 import amazonSchemaData from '@pageSchemas/amazonSchema.json';
 import type { PageSchema } from '@blocks/shared/Page';
@@ -21,6 +22,7 @@ function App() {
   return (
     <PageSchemaProvider>
       <HistoryProvider initialSchema={amazonSchemaData as PageSchema}>
+      <SavePageProvider>
         <SelectionProvider>
           <BlockInsertProvider>
             <LibraryPanelProvider>
@@ -47,6 +49,7 @@ function App() {
             </LibraryPanelProvider>
           </BlockInsertProvider>
         </SelectionProvider>
+        </SavePageProvider>
       </HistoryProvider>
     </PageSchemaProvider>
   );

--- a/src/components/Notification.tsx
+++ b/src/components/Notification.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 
 export type NotificationType = 'success' | 'error' | 'warning' | 'info';
 
@@ -9,6 +9,58 @@ export interface NotificationProps {
   onClose: () => void;
   duration?: number;
 }
+
+// Styling configuration for each notification type
+const NOTIFICATION_STYLES = {
+  success: {
+    container: 'bg-green-50 border-green-300',
+    text: 'text-green-800',
+    icon: 'text-green-400',
+    button: 'bg-green-50 text-green-500 hover:bg-green-100 focus:ring-offset-green-50 focus:ring-green-600'
+  },
+  error: {
+    container: 'bg-red-50 border-red-300',
+    text: 'text-red-800',
+    icon: 'text-red-400',
+    button: 'bg-red-50 text-red-500 hover:bg-red-100 focus:ring-offset-red-50 focus:ring-red-600'
+  },
+  warning: {
+    container: 'bg-yellow-50 border-yellow-300',
+    text: 'text-yellow-800',
+    icon: 'text-yellow-400',
+    button: 'bg-yellow-50 text-yellow-500 hover:bg-yellow-100 focus:ring-offset-yellow-50 focus:ring-yellow-600'
+  },
+  info: {
+    container: 'bg-indigo-50 border-indigo-300',
+    text: 'text-indigo-800',
+    icon: 'text-indigo-400',
+    button: 'bg-indigo-50 text-indigo-600 hover:bg-indigo-100 focus:ring-offset-indigo-50 focus:ring-indigo-700'
+  }
+} as const;
+
+// Icon components for each notification type
+const NotificationIcons = {
+  success: (className: string) => (
+    <svg className={className} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+    </svg>
+  ),
+  error: (className: string) => (
+    <svg className={className} viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+      <path fillRule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16ZM8.28 7.22a.75.75 0 0 0-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 1 0 1.06 1.06L10 11.06l1.72 1.72a.75.75 0 1 0 1.06-1.06L11.06 10l1.72-1.72a.75.75 0 0 0-1.06-1.06L10 8.94 8.28 7.22Z" clipRule="evenodd" />
+    </svg>
+  ),
+  warning: (className: string) => (
+    <svg className={className} viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+      <path fillRule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clipRule="evenodd" />
+    </svg>
+  ),
+  info: (className: string) => (
+    <svg className={className} viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+      <path fillRule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clipRule="evenodd" />
+    </svg>
+  )
+} as const;
 
 const Notification: React.FC<NotificationProps> = ({
   type,
@@ -24,74 +76,22 @@ const Notification: React.FC<NotificationProps> = ({
     }
   }, [isVisible, duration, onClose]);
 
+  // Memoize styling and icon to prevent recreation on every render
+  const styling = useMemo(() => NOTIFICATION_STYLES[type] || NOTIFICATION_STYLES.info, [type]);
+  
+  const icon = useMemo(() => {
+    const IconComponent = NotificationIcons[type] || NotificationIcons.info;
+    return IconComponent(`h-5 w-5 ${styling.icon}`);
+  }, [type, styling.icon]);
+
   if (!isVisible) return null;
-
-  // Get styling based on type
-  const getStyling = () => {
-    switch (type) {
-      case 'success':
-        return {
-          container: 'bg-green-50 border-green-300',
-          text: 'text-green-800',
-          icon: 'text-green-400',
-          button: 'bg-green-50 text-green-500 hover:bg-green-100 focus:ring-offset-green-50 focus:ring-green-600'
-        };
-      case 'error':
-        return {
-          container: 'bg-red-50 border-red-300',
-          text: 'text-red-800',
-          icon: 'text-red-400',
-          button: 'bg-red-50 text-red-500 hover:bg-red-100 focus:ring-offset-red-50 focus:ring-red-600'
-        };
-      case 'warning':
-        return {
-          container: 'bg-yellow-50 border-yellow-300',
-          text: 'text-yellow-800',
-          icon: 'text-yellow-400',
-          button: 'bg-yellow-50 text-yellow-500 hover:bg-yellow-100 focus:ring-offset-yellow-50 focus:ring-yellow-600'
-        };
-      default:
-        return {
-          container: 'bg-indigo-50 border-indigo-300',
-          text: 'text-indigo-800',
-          icon: 'text-indigo-400',
-          button: 'bg-indigo-50 text-indigo-600 hover:bg-indigo-100 focus:ring-offset-indigo-50 focus:ring-indigo-700'
-        };
-    }
-  };
-
-  const styling = getStyling();
-
-  // Get icon SVG based on type
-  const getIcon = () => {
-    switch (type) {
-      case 'success':
-        return (
-          <svg className={`h-5 w-5 ${styling.icon}`} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-            <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
-          </svg>
-        );
-      case 'error':
-        return (
-          <svg className={`h-5 w-5 ${styling.icon}`} viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
-            <path fillRule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16ZM8.28 7.22a.75.75 0 0 0-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 1 0 1.06 1.06L10 11.06l1.72 1.72a.75.75 0 1 0 1.06-1.06L11.06 10l1.72-1.72a.75.75 0 0 0-1.06-1.06L10 8.94 8.28 7.22Z" clipRule="evenodd" />
-          </svg>
-        );
-      default:
-        return (
-          <svg className={`h-5 w-5 ${styling.icon}`} viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
-            <path fillRule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clipRule="evenodd" />
-          </svg>
-        );
-    }
-  };
 
   return (
     <div className="w-full absolute flex flex-col items-center gap-2 z-50 top-2">
       <div className={`rounded border ${styling.container} py-1.5 px-3`}>
         <div className="flex items-center">
           <div className="flex-shrink-0">
-            {getIcon()}
+            {icon}
           </div>
           <div className="ml-3">
             <p className={`text-sm font-medium ${styling.text}`}>

--- a/src/components/Notification.tsx
+++ b/src/components/Notification.tsx
@@ -1,0 +1,121 @@
+import React, { useEffect } from 'react';
+
+export type NotificationType = 'success' | 'error' | 'warning' | 'info';
+
+export interface NotificationProps {
+  type: NotificationType;
+  message: string;
+  isVisible: boolean;
+  onClose: () => void;
+  duration?: number;
+}
+
+const Notification: React.FC<NotificationProps> = ({
+  type,
+  message,
+  isVisible,
+  onClose,
+  duration = 5000
+}) => {
+  useEffect(() => {
+    if (isVisible && duration > 0) {
+      const timer = setTimeout(onClose, duration);
+      return () => clearTimeout(timer);
+    }
+  }, [isVisible, duration, onClose]);
+
+  if (!isVisible) return null;
+
+  // Get styling based on type
+  const getStyling = () => {
+    switch (type) {
+      case 'success':
+        return {
+          container: 'bg-green-50 border-green-300',
+          text: 'text-green-800',
+          icon: 'text-green-400',
+          button: 'bg-green-50 text-green-500 hover:bg-green-100 focus:ring-offset-green-50 focus:ring-green-600'
+        };
+      case 'error':
+        return {
+          container: 'bg-red-50 border-red-300',
+          text: 'text-red-800',
+          icon: 'text-red-400',
+          button: 'bg-red-50 text-red-500 hover:bg-red-100 focus:ring-offset-red-50 focus:ring-red-600'
+        };
+      case 'warning':
+        return {
+          container: 'bg-yellow-50 border-yellow-300',
+          text: 'text-yellow-800',
+          icon: 'text-yellow-400',
+          button: 'bg-yellow-50 text-yellow-500 hover:bg-yellow-100 focus:ring-offset-yellow-50 focus:ring-yellow-600'
+        };
+      default:
+        return {
+          container: 'bg-indigo-50 border-indigo-300',
+          text: 'text-indigo-800',
+          icon: 'text-indigo-400',
+          button: 'bg-indigo-50 text-indigo-600 hover:bg-indigo-100 focus:ring-offset-indigo-50 focus:ring-indigo-700'
+        };
+    }
+  };
+
+  const styling = getStyling();
+
+  // Get icon SVG based on type
+  const getIcon = () => {
+    switch (type) {
+      case 'success':
+        return (
+          <svg className={`h-5 w-5 ${styling.icon}`} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+          </svg>
+        );
+      case 'error':
+        return (
+          <svg className={`h-5 w-5 ${styling.icon}`} viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+            <path fillRule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16ZM8.28 7.22a.75.75 0 0 0-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 1 0 1.06 1.06L10 11.06l1.72 1.72a.75.75 0 1 0 1.06-1.06L11.06 10l1.72-1.72a.75.75 0 0 0-1.06-1.06L10 8.94 8.28 7.22Z" clipRule="evenodd" />
+          </svg>
+        );
+      default:
+        return (
+          <svg className={`h-5 w-5 ${styling.icon}`} viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+            <path fillRule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clipRule="evenodd" />
+          </svg>
+        );
+    }
+  };
+
+  return (
+    <div className="w-full absolute flex flex-col items-center gap-2 z-50 top-2">
+      <div className={`rounded border ${styling.container} py-1.5 px-3`}>
+        <div className="flex items-center">
+          <div className="flex-shrink-0">
+            {getIcon()}
+          </div>
+          <div className="ml-3">
+            <p className={`text-sm font-medium ${styling.text}`}>
+              {message}
+            </p>
+          </div>
+          <div className="ml-auto pl-3">
+            <div className="h-5 w-5">
+              <button
+                type="button"
+                onClick={onClose}
+                className={`inline-flex rounded-sm focus:outline-none focus:ring-2 ${styling.button}`}
+              >
+                <span className="sr-only">Dismiss</span>
+                <svg className="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Notification;

--- a/src/context/SavePageContext.tsx
+++ b/src/context/SavePageContext.tsx
@@ -1,0 +1,75 @@
+import React, { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
+import { useHistory } from '@context/HistoryContext';
+import { savePage, type SavePageRequest, type SavePageResponse } from '@services/api/page';
+
+interface SavePageContextType {
+  isSaving: boolean;
+  savePage: (title?: string, description?: string, status?: number, slug?: string) => Promise<SavePageResponse>;
+  lastError: string | null;
+  lastSuccess: string | null;
+}
+
+const SavePageContext = createContext<SavePageContextType | undefined>(undefined);
+
+interface SavePageProviderProps {
+  children: ReactNode;
+}
+
+export const SavePageProvider: React.FC<SavePageProviderProps> = ({ children }) => {
+  const { pageSchema } = useHistory();
+  const [isSaving, setIsSaving] = useState(false);
+  const [lastError, setLastError] = useState<string | null>(null);
+  const [lastSuccess, setLastSuccess] = useState<string | null>(null);
+
+  const handleSave = useCallback(async (
+    title?: string, 
+    description?: string,
+    status: number = 1,
+    slug?: string
+  ): Promise<SavePageResponse> => {
+    try {
+      setIsSaving(true);
+      setLastError(null);
+      setLastSuccess(null);
+
+      const pageData: SavePageRequest = {
+        title: title || pageSchema.title || 'Home Page',
+        schema: pageSchema,
+        status,
+        description: description || `Page saved on ${new Date().toLocaleDateString()}`,
+        slug: slug || "home"  // Use provided slug or default to "home"
+      };
+
+      const response = await savePage(pageData);
+      
+      const statusText = status === 1 ? 'draft' : 'published';
+      setLastSuccess(`Page saved as ${statusText} successfully!`);
+      return response;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Failed to save page. Please try again.';
+      setLastError(errorMessage);
+      throw error;
+    } finally {
+      setIsSaving(false);
+    }
+  }, [pageSchema]);
+
+  return (
+    <SavePageContext.Provider value={{
+      isSaving,
+      savePage: handleSave,
+      lastError,
+      lastSuccess
+    }}>
+      {children}
+    </SavePageContext.Provider>
+  );
+};
+
+export const useSavePage = (): SavePageContextType => {
+  const context = useContext(SavePageContext);
+  if (context === undefined) {
+    throw new Error('useSavePage must be used within a SavePageProvider');
+  }
+  return context;
+};

--- a/src/context/SavePageContext.tsx
+++ b/src/context/SavePageContext.tsx
@@ -36,8 +36,8 @@ export const SavePageProvider: React.FC<SavePageProviderProps> = ({ children }) 
         title: title || pageSchema.title || 'Home Page',
         schema: pageSchema,
         status,
-        description: description || `Page saved on ${new Date().toLocaleDateString()}`,
-        slug: slug || "home"  // Use provided slug or default to "home"
+        description: description || `Page saved on ${new Date().toLocaleString()}`,
+        slug: slug || "home"  // Default slug for backward compatibility
       };
 
       const response = await savePage(pageData);

--- a/src/layout/TopBar.tsx
+++ b/src/layout/TopBar.tsx
@@ -42,27 +42,40 @@ const TopBar: React.FC = () => {
     setIsPageSchemaDropdownOpen(false);
   };
 
-  const handleSave = async (status: number = 1) => {
+  const handleSave = React.useCallback(async (status: number = 1) => {
     try {
       await savePage(undefined, undefined, status);
-      setNotification({
-        type: 'success',
-        message: lastSuccess || 'Page saved successfully!',
-        isVisible: true
-      });
       setIsSaveDropdownOpen(false);
     } catch (error) {
-      setNotification({
-        type: 'error',
-        message: lastError || 'Failed to save page. Please try again.',
-        isVisible: true
-      });
+      console.error(error);
     }
-  };
+  }, [savePage]);
 
   const closeNotification = () => {
     setNotification(prev => ({ ...prev, isVisible: false }));
   };
+
+  // Handle success notifications
+  React.useEffect(() => {
+    if (lastSuccess) {
+      setNotification({
+        type: 'success',
+        message: lastSuccess,
+        isVisible: true
+      });
+    }
+  }, [lastSuccess]);
+
+  // Handle error notifications
+  React.useEffect(() => {
+    if (lastError) {
+      setNotification({
+        type: 'error',
+        message: lastError,
+        isVisible: true
+      });
+    }
+  }, [lastError]);
 
   // Keyboard shortcut handler
   React.useEffect(() => {
@@ -77,7 +90,7 @@ const TopBar: React.FC = () => {
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [isSaving]);
+  }, [isSaving, handleSave]);
 
   return (
     <div className="sticky top-0 left-0 right-0 z-50 bg-gray-800 text-white p-4 border-b border-gray-700">

--- a/src/layout/TopBar.tsx
+++ b/src/layout/TopBar.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import { Undo, Redo, Plus, X, ChevronDown,Layers } from 'lucide-react';
+import { Undo, Redo, Plus, X, ChevronDown, Layers, Save, Loader2, FileText, Globe } from 'lucide-react';
 import { useHistory } from '@context/HistoryContext';
 import { useLibraryPanel } from '@context/LibraryPanelContext';
 import { useLayoutPanel } from '@context/LayoutPanelContext';
 import { usePanelCoordinator } from '@context/PanelCoordinator';
 import { usePageSchema, availablePageSchemas, type PageSchemaKey } from '@context/PageSchemaContext';
 import { useOnClickOutside } from '@hooks/useOnClickOutside';
+import Notification, { type NotificationType } from '@components/Notification';
+import { useSavePage } from '@context/SavePageContext';
 
 const TopBar: React.FC = () => {
   const { undo, canUndo, redo, canRedo, updatePageSchema } = useHistory();
@@ -13,11 +15,24 @@ const TopBar: React.FC = () => {
   const { isLayoutOpen } = useLayoutPanel();
   const { toggleLibrarySafely, toggleLayoutSafely } = usePanelCoordinator();
   const { currentPageSchemaKey, setCurrentPageSchemaKey } = usePageSchema();
+  const { isSaving, savePage, lastError, lastSuccess } = useSavePage();
   
   const [isPageSchemaDropdownOpen, setIsPageSchemaDropdownOpen] = React.useState(false);
+  const [isSaveDropdownOpen, setIsSaveDropdownOpen] = React.useState(false);
+  const [notification, setNotification] = React.useState<{
+    type: NotificationType;
+    message: string;
+    isVisible: boolean;
+  }>({
+    type: 'success',
+    message: '',
+    isVisible: false
+  });
   const dropdownRef = React.useRef<HTMLDivElement>(null);
+  const saveDropdownRef = React.useRef<HTMLDivElement>(null);
   
   useOnClickOutside(dropdownRef, () => setIsPageSchemaDropdownOpen(false));
+  useOnClickOutside(saveDropdownRef, () => setIsSaveDropdownOpen(false));
   
   const handlePageSchemaChange = (pageSchemaKey: PageSchemaKey) => {
     // This logic is moved from the hook - orchestrating both contexts
@@ -26,6 +41,43 @@ const TopBar: React.FC = () => {
     updatePageSchema(newPageSchema);
     setIsPageSchemaDropdownOpen(false);
   };
+
+  const handleSave = async (status: number = 1) => {
+    try {
+      await savePage(undefined, undefined, status);
+      setNotification({
+        type: 'success',
+        message: lastSuccess || 'Page saved successfully!',
+        isVisible: true
+      });
+      setIsSaveDropdownOpen(false);
+    } catch (error) {
+      setNotification({
+        type: 'error',
+        message: lastError || 'Failed to save page. Please try again.',
+        isVisible: true
+      });
+    }
+  };
+
+  const closeNotification = () => {
+    setNotification(prev => ({ ...prev, isVisible: false }));
+  };
+
+  // Keyboard shortcut handler
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.ctrlKey || event.metaKey) && event.key === 's') {
+        event.preventDefault();
+        if (!isSaving) {
+          handleSave(1); // Default to draft
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isSaving]);
 
   return (
     <div className="sticky top-0 left-0 right-0 z-50 bg-gray-800 text-white p-4 border-b border-gray-700">
@@ -101,14 +153,54 @@ const TopBar: React.FC = () => {
             <span>Redo</span>
             <Redo className="w-4 h-4" />
           </button>
-          <button className="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded">
-            Save
-          </button>
+          {/* Save Dropdown */}
+          <div className="relative" ref={saveDropdownRef}>
+            <button 
+              onClick={() => setIsSaveDropdownOpen(!isSaveDropdownOpen)}
+              disabled={isSaving}
+              className={`px-4 py-2 rounded flex items-center space-x-2 transition-colors ${
+                isSaving 
+                  ? 'bg-gray-600 cursor-not-allowed' 
+                  : 'bg-green-600 hover:bg-green-700'
+              }`}
+              title={isSaving ? 'Saving...' : 'Save page (Ctrl+S / Cmd+S)'}
+            >
+              {isSaving ? <Loader2 size={16} className="animate-spin" /> : <Save size={16} />}
+              <span>{isSaving ? 'Saving...' : 'Save'}</span>
+              <ChevronDown size={16} className={`transition-transform ${isSaveDropdownOpen ? 'rotate-180' : ''}`} />
+            </button>
+            
+            {isSaveDropdownOpen && !isSaving && (
+              <div className="absolute top-full right-0 mt-1 bg-gray-700 rounded shadow-lg w-48 z-50">
+                <button
+                  onClick={() => handleSave(1)}
+                  className="w-full text-left px-4 py-2 hover:bg-gray-600 flex items-center space-x-2"
+                >
+                  <FileText size={16} />
+                  <span>Save as Draft</span>
+                </button>
+                <button
+                  onClick={() => handleSave(2)}
+                  className="w-full text-left px-4 py-2 hover:bg-gray-600 flex items-center space-x-2"
+                >
+                  <Globe size={16} />
+                  <span>Publish</span>
+                </button>
+              </div>
+            )}
+          </div>
           <button className="px-4 py-2 bg-green-600 hover:bg-green-700 rounded">
             Preview
           </button>
         </div>
       </div>
+      
+      <Notification
+        type={notification.type}
+        message={notification.message}
+        isVisible={notification.isVisible}
+        onClose={closeNotification}
+      />
     </div>
   );
 };

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -1,1 +1,2 @@
 export * from './movie';
+export * from './page';

--- a/src/services/api/page.ts
+++ b/src/services/api/page.ts
@@ -60,7 +60,7 @@ export async function savePage(pageData: SavePageRequest): Promise<SavePageRespo
     throw new Error('A slug must be provided to save the page.');
   }
 
-  const response = await fetch(`${baseUrl}/api/v1/page/save/${slug}/`, {
+  const response = await fetch(`${baseUrl}/api/v1/page/${slug}/save/`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',

--- a/src/services/api/page.ts
+++ b/src/services/api/page.ts
@@ -6,7 +6,7 @@ export interface SavePageRequest {
   schema: PageSchema;
   status: number;
   description: string;
-  slug?: string;
+  slug: string;
 }
 
 // Response from the Django API
@@ -49,15 +49,18 @@ declare global {
  * @throws Error if the API request fails
  */
 export async function savePage(pageData: SavePageRequest): Promise<SavePageResponse> {
-  // Get CSRF token from Django data
-  const csrfToken = window.DJANGO_DATA?.csrf_token;
-  if (!csrfToken) {
-    throw new Error('CSRF token not found. Please refresh the page and try again.');
-  } 
+  // Get CSRF token and base URL from Django data
+  const { csrf_token: csrfToken, base_url: baseUrl } = window.DJANGO_DATA || {};
+  if (!csrfToken || !baseUrl) {
+    throw new Error('CSRF token or base URL not found. Please refresh the page and try again.');
+  }
   
-  const slug = pageData.slug || "home";
+  const slug = pageData.slug;
+  if (!slug) {
+    throw new Error('A slug must be provided to save the page.');
+  }
 
-  const response = await fetch(`${window.DJANGO_DATA?.base_url}/api/v1/page/save/${slug}/`, {
+  const response = await fetch(`${baseUrl}/api/v1/page/save/${slug}/`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',

--- a/src/services/api/page.ts
+++ b/src/services/api/page.ts
@@ -1,0 +1,75 @@
+import type { PageSchema } from '@blocks/shared/Page';
+
+// Request payload for saving a page
+export interface SavePageRequest {
+  title: string;
+  schema: PageSchema;
+  status: number;
+  description: string;
+  slug?: string;
+}
+
+// Response from the Django API
+export interface SavePageResponse {
+  success: boolean;
+  message: string;
+  data: {
+    id: number;
+    title: string;
+    slug: string;
+    schema: PageSchema;
+    status: number;
+    version: number;
+    description: string;
+  };
+}
+
+// Error response from the Django API
+export interface ApiErrorResponse {
+  success: false;
+  message: string;
+  error: string;
+}
+
+// Global Django data interface
+declare global {
+  interface Window {
+    DJANGO_DATA: {
+      csrf_token: string;
+      base_url: string;
+    };
+  }
+}
+
+
+/**
+ * Saves a page to the Django backend API
+ * @param pageData - The page data to save
+ * @returns Promise<SavePageResponse> - The API response
+ * @throws Error if the API request fails
+ */
+export async function savePage(pageData: SavePageRequest): Promise<SavePageResponse> {
+  // Get CSRF token from Django data
+  const csrfToken = window.DJANGO_DATA?.csrf_token;
+  if (!csrfToken) {
+    throw new Error('CSRF token not found. Please refresh the page and try again.');
+  } 
+  
+  const slug = pageData.slug || "home";
+
+  const response = await fetch(`${window.DJANGO_DATA?.base_url}/api/v1/page/save/${slug}/`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRFToken': csrfToken
+    },
+    body: JSON.stringify(pageData)
+  });
+
+  if (!response.ok) {
+    const errorData: ApiErrorResponse = await response.json();
+    throw new Error(errorData.message || `HTTP ${response.status}: Failed to save page`);
+  }
+
+  return response.json() as Promise<SavePageResponse>;
+}


### PR DESCRIPTION
- Add page save API service with CSRF token handling
- Implement SavePageContext for state management
- Create reusable Notification component with multiple types
- Integrate save functionality in TopBar with dropdown options
- Add keyboard shortcut support (Ctrl+S/Cmd+S)
- Support both draft and published page states
- Add comprehensive error handling and user feedback