### PR TITLE
feat: implement multi-page support with page switching

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,22 +12,33 @@ import { SettingsPanelProvider } from '@context/SettingsPanelContext';
 import { PageSchemaProvider } from '@context/PageSchemaContext';
 import { PanelCoordinatorProvider } from '@context/PanelCoordinator';
 import { useState } from 'react';
-import amazonSchemaData from '@pageSchemas/amazonSchema.json';
 import type { PageSchema } from '@blocks/shared/Page';
+import amazonSchemaData from '@pageSchemas/amazonSchema.json';
 
 export type AppProps = {
-  initialSchema?: PageSchema;
-  onSave?: (schema: PageSchema) => void;
+  initialPages?: Record<string, PageSchema>;
+  defaultPageSlug?: string;
+  onSave?: (pageSlug: string, schema: PageSchema) => void;
 };
 
-function App({ initialSchema, onSave }: AppProps) {
+function App({ initialPages, defaultPageSlug, onSave }: AppProps) {
   const [showDebug, setShowDebug] = useState(false);
   
-  const schema = initialSchema || (amazonSchemaData as PageSchema);
+  // Provide default values if not provided
+  const pages = initialPages || {
+    'home': amazonSchemaData as PageSchema
+  };
+  const currentPageSlug = defaultPageSlug || 'home';
+  
+  // Get the initial schema for HistoryProvider (using the default page)
+  const initialSchema = pages[currentPageSlug];
 
   return (
-    <PageSchemaProvider>
-      <HistoryProvider initialSchema={schema}>
+    <PageSchemaProvider 
+      initialPages={pages} 
+      defaultPageSlug={currentPageSlug}
+    >
+      <HistoryProvider initialSchema={initialSchema}>
         <SelectionProvider>
           <BlockInsertProvider>
             <LibraryPanelProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,16 +16,18 @@ import type { PageSchema } from '@blocks/shared/Page';
 import amazonSchemaData from '@pageSchemas/amazonSchema.json';
 
 export type AppProps = {
-  initialPages?: Record<string, PageSchema>;
+  initialPage?: Record<string, PageSchema>;
   defaultPageSlug?: string;
-  onSave?: (pageSlug: string, schema: PageSchema) => void;
+  pagesList?: string[];
+  onSave?: (pageSlug: string, schema: PageSchema) => Promise<any>;
+  onLoadPage?: (slug: string) => Promise<{ slug: string; schema: PageSchema }>;
 };
 
-function App({ initialPages, defaultPageSlug, onSave }: AppProps) {
+function App({ initialPage, defaultPageSlug, pagesList, onSave, onLoadPage }: AppProps) {
   const [showDebug, setShowDebug] = useState(false);
   
   // Provide default values if not provided
-  const pages = initialPages || {
+  const pages = initialPage || {
     'home': amazonSchemaData as PageSchema
   };
   const currentPageSlug = defaultPageSlug || 'home';
@@ -35,8 +37,10 @@ function App({ initialPages, defaultPageSlug, onSave }: AppProps) {
 
   return (
     <PageSchemaProvider 
-      initialPages={pages} 
+      initialPage={pages} 
+      pagesList={pagesList}
       defaultPageSlug={currentPageSlug}
+      onLoadPage={onLoadPage}
     >
       <HistoryProvider initialSchema={initialSchema}>
         <SelectionProvider>

--- a/src/context/HistoryContext.tsx
+++ b/src/context/HistoryContext.tsx
@@ -31,17 +31,22 @@ export const HistoryProvider: React.FC<HistoryProviderProps> = ({ children, init
   
   // Get PageSchemaContext for multi-page support
   const { currentPageSlug, pages, updateSpecificPage } = usePageSchema();
+  const prevPageSlugRef = React.useRef(currentPageSlug);
 
   // Sync with current page when page changes
   React.useEffect(() => {
     const currentPage = pages[currentPageSlug];
-    if (currentPage && currentPage !== pageSchema) {
+    if (currentPage) {
       setPageSchema(currentPage);
-      // Clear history when switching pages
-      setUndoStack([]);
-      setRedoStack([]);
+      
+      // Only clear history when actually switching pages
+      if (currentPageSlug !== prevPageSlugRef.current) {
+        setUndoStack([]);
+        setRedoStack([]);
+        prevPageSlugRef.current = currentPageSlug;
+      }
     }
-  }, [currentPageSlug, pages, pageSchema]);
+  }, [currentPageSlug, pages]);
 
   // Exposed function to record state changes
   const recordState = (currentBlocks: BlockType[]) => {

--- a/src/context/HistoryContext.tsx
+++ b/src/context/HistoryContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState, type ReactNode } from 'react';
 import type { BlockType } from '@blocks/shared/Block';
 import type { PageSchema } from '@blocks/shared/Page';
+import { usePageSchema } from './PageSchemaContext';
 
 interface HistoryContextType {
   pageSchema: PageSchema;
@@ -27,6 +28,20 @@ export const HistoryProvider: React.FC<HistoryProviderProps> = ({ children, init
   const [pageSchema, setPageSchema] = useState<PageSchema>(initialSchema);
   const [undoStack, setUndoStack] = useState<PageSchema[]>([]);
   const [redoStack, setRedoStack] = useState<PageSchema[]>([]);
+  
+  // Get PageSchemaContext for multi-page support
+  const { currentPageSlug, pages, updateSpecificPage } = usePageSchema();
+
+  // Sync with current page when page changes
+  React.useEffect(() => {
+    const currentPage = pages[currentPageSlug];
+    if (currentPage && currentPage !== pageSchema) {
+      setPageSchema(currentPage);
+      // Clear history when switching pages
+      setUndoStack([]);
+      setRedoStack([]);
+    }
+  }, [currentPageSlug, pages, pageSchema]);
 
   // Exposed function to record state changes
   const recordState = (currentBlocks: BlockType[]) => {
@@ -43,11 +58,15 @@ export const HistoryProvider: React.FC<HistoryProviderProps> = ({ children, init
   const updatePageWithHistory = (newSchema: PageSchema) => {
     recordState(pageSchema.blocks);
     setPageSchema(newSchema);
+    // Also update the page in multi-page system
+    updateSpecificPage(currentPageSlug, newSchema);
   };
 
   // Public function to update page schema without history recording (for page schema switching)
   const updatePageSchema = (newPageSchema: PageSchema) => {
     setPageSchema(newPageSchema);
+    // Also update the page in multi-page system
+    updateSpecificPage(currentPageSlug, newPageSchema);
     // Clear history when switching page schemas
     setUndoStack([]);
     setRedoStack([]);
@@ -62,6 +81,8 @@ export const HistoryProvider: React.FC<HistoryProviderProps> = ({ children, init
     
     const previousSchema = undoStack[undoStack.length - 1];
     setPageSchema(previousSchema);
+    // Also update the page in multi-page system
+    updateSpecificPage(currentPageSlug, previousSchema);
     setUndoStack(prev => prev.slice(0, -1)); //remove the last item from the undo stack
   };
 
@@ -76,6 +97,8 @@ export const HistoryProvider: React.FC<HistoryProviderProps> = ({ children, init
     
     const nextSchema = redoStack[redoStack.length - 1];
     setPageSchema(nextSchema);
+    // Also update the page in multi-page system
+    updateSpecificPage(currentPageSlug, nextSchema);
     setRedoStack(prev => prev.slice(0, -1));
   };
 

--- a/src/context/PageSchemaContext.tsx
+++ b/src/context/PageSchemaContext.tsx
@@ -1,53 +1,50 @@
 import React, { createContext, useContext, useState, type ReactNode } from 'react';
 import type { PageSchema } from '@blocks/shared/Page';
-import netflixSchemaData from '@pageSchemas/netflixSchema.json';
-import hotstarSchemaData from '@pageSchemas/hotstarSchema.json';
-import amazonSchemaData from '@pageSchemas/amazonSchema.json';
 
-// Define available page schemas
-export const availablePageSchemas = {
-  netflix: {
-    name: 'Netflix Page',
-    pageSchema: netflixSchemaData as PageSchema
-  },
-  hotstar: {
-    name: 'Hotstar Page',
-    pageSchema: hotstarSchemaData as PageSchema
-  },
-  amazon: {
-    name: 'Amazon Prime Page',
-    pageSchema: amazonSchemaData as PageSchema
-  }
-};
-
-export type PageSchemaKey = keyof typeof availablePageSchemas;
-
+// Multi-page context interface
 interface PageSchemaContextType {
-  currentPageSchemaKey: PageSchemaKey;
-  currentPageSchema: PageSchema;
-  setCurrentPageSchemaKey: (key: PageSchemaKey) => void;
+  pages: Record<string, PageSchema>;
+
+  // setPages: React's setState function - can update all pages at once
+  // Usage: setPages(newPages) or setPages(prevPages => newPages)
+  // Example: setPages(prev => ({ ...prev, 'movies': updatedMoviesPage })) - updates specific page in the map
+  setPages: React.Dispatch<React.SetStateAction<Record<string, PageSchema>>>;
+  currentPageSlug: string;
+  setCurrentPageSlug: (slug: string) => void;
+  updateSpecificPage: (slug: string, schema: PageSchema) => void;
 }
 
 const PageSchemaContext = createContext<PageSchemaContextType | undefined>(undefined);
 
 interface PageSchemaProviderProps {
   children: ReactNode;
-  initialPageSchemaKey?: PageSchemaKey;
+  initialPages: Record<string, PageSchema>;
+  defaultPageSlug: string;
 }
 
 export const PageSchemaProvider: React.FC<PageSchemaProviderProps> = ({ 
   children, 
-  initialPageSchemaKey = 'amazon' as PageSchemaKey
+  initialPages,
+  defaultPageSlug
 }) => {
-  const [currentPageSchemaKey, setCurrentPageSchemaKey] = useState<PageSchemaKey>(initialPageSchemaKey);
+  const [pages, setPages] = useState<Record<string, PageSchema>>(initialPages);
+  const [currentPageSlug, setCurrentPageSlug] = useState<string>(defaultPageSlug);
 
-  const currentPageSchema = availablePageSchemas[currentPageSchemaKey].pageSchema;
+  // Update specific page helper
+  const updateSpecificPage = (slug: string, schema: PageSchema) => {
+    setPages(prev => ({
+      ...prev,
+      [slug]: schema
+    }));
+  };
 
   return (
     <PageSchemaContext.Provider value={{
-      currentPageSchemaKey,
-      currentPageSchema,
-      setCurrentPageSchemaKey
+      pages,
+      setPages,
+      currentPageSlug,
+      setCurrentPageSlug,
+      updateSpecificPage
     }}>
       {children}
     </PageSchemaContext.Provider>

--- a/src/context/PageSchemaContext.tsx
+++ b/src/context/PageSchemaContext.tsx
@@ -31,12 +31,12 @@ export const PageSchemaProvider: React.FC<PageSchemaProviderProps> = ({
   const [currentPageSlug, setCurrentPageSlug] = useState<string>(defaultPageSlug);
 
   // Update specific page helper
-  const updateSpecificPage = (slug: string, schema: PageSchema) => {
+  const updateSpecificPage = React.useCallback((slug: string, schema: PageSchema) => {
     setPages(prev => ({
       ...prev,
       [slug]: schema
     }));
-  };
+  }, []);
 
   return (
     <PageSchemaContext.Provider value={{

--- a/src/context/SelectionContext.tsx
+++ b/src/context/SelectionContext.tsx
@@ -69,20 +69,20 @@ export const SelectionProvider: React.FC<SelectionProviderProps> = ({ children }
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
   const [selectedItemBlockId, setSelectedItemBlockId] = useState<string | null>(null);
   const [activeTabId, setActiveTabId] = useState<string | null>(null);
-  const [lastPageSlug, setLastPageSlug] = useState<string>(currentPageSlug);
+  const prevPageSlugRef = React.useRef(currentPageSlug);
 
   // Clear selection only when switching pages
   useEffect(() => {
-    if (currentPageSlug !== lastPageSlug) {
+    if (currentPageSlug !== prevPageSlugRef.current) {
       setSelectedBlock(null);
       setSelectedBlockId(null);
       setSelectedBlockParentId(null);
       setSelectedItemId(null);
       setSelectedItemBlockId(null);
       setActiveTabId(null);
-      setLastPageSlug(currentPageSlug);
+      prevPageSlugRef.current = currentPageSlug;
     }
-  }, [currentPageSlug, lastPageSlug]);
+  }, [currentPageSlug]);
 
   // Helper function to recursively check if a block exists in the schema
   const blockExistsInSchema = (blockId: string, blocks: BlockType[]): boolean => {

--- a/src/context/SelectionContext.tsx
+++ b/src/context/SelectionContext.tsx
@@ -9,6 +9,7 @@ import { swap } from '@utils/array';
 import { generateUniqueId } from '@utils/id';
 import type { TabsBlock, Tab } from '@blocks/tabs/schema';
 import { useHistory } from './HistoryContext';
+import { usePageSchema } from './PageSchemaContext';
 
 interface SelectionContextType {
   selectedBlock: Block | null;
@@ -60,6 +61,7 @@ interface SelectionProviderProps {
 
 export const SelectionProvider: React.FC<SelectionProviderProps> = ({ children }) => {
   const { pageSchema, updatePageWithHistory } = useHistory();
+  const { currentPageSlug } = usePageSchema();
 
   const [selectedBlock, setSelectedBlock] = useState<Block | null>(null);
   const [selectedBlockId, setSelectedBlockId] = useState<string | null>(null);
@@ -67,6 +69,20 @@ export const SelectionProvider: React.FC<SelectionProviderProps> = ({ children }
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
   const [selectedItemBlockId, setSelectedItemBlockId] = useState<string | null>(null);
   const [activeTabId, setActiveTabId] = useState<string | null>(null);
+  const [lastPageSlug, setLastPageSlug] = useState<string>(currentPageSlug);
+
+  // Clear selection only when switching pages
+  useEffect(() => {
+    if (currentPageSlug !== lastPageSlug) {
+      setSelectedBlock(null);
+      setSelectedBlockId(null);
+      setSelectedBlockParentId(null);
+      setSelectedItemId(null);
+      setSelectedItemBlockId(null);
+      setActiveTabId(null);
+      setLastPageSlug(currentPageSlug);
+    }
+  }, [currentPageSlug, lastPageSlug]);
 
   // Helper function to recursively check if a block exists in the schema
   const blockExistsInSchema = (blockId: string, blocks: BlockType[]): boolean => {

--- a/src/layout/Canvas.tsx
+++ b/src/layout/Canvas.tsx
@@ -4,6 +4,7 @@ import BlockInsertDropdown from '@layout/BlockInsertDropdown';
 import type { Platform, VisibilityContext } from '@blocks/shared/Visibility';
 import type { Block } from '@blocks/shared/Block';
 import { useSelection } from '@context/SelectionContext';
+import { usePageSchema } from '@context/PageSchemaContext';
 import { Search } from 'lucide-react';
 
 interface CanvasProps {
@@ -21,10 +22,13 @@ const Canvas: React.FC<CanvasProps> = ({ showDebug }) => {
     setSelectedBlockId,
     setSelectedBlock,
     setSelectedItemId,
-    setSelectedItemBlockId,
-    pageSchema 
+    setSelectedItemBlockId
   } = useSelection();
+  const { pages, currentPageSlug } = usePageSchema();
   const [visibilityContext, setVisibilityContext] = React.useState<VisibilityContext>(initialVisibilityContext);
+
+  // Get the current page from PageSchemaContext
+  const currentPage = pages[currentPageSlug];
 
   const handleBlockSelect = (block: Block) => {
     // Only clear item selection if selecting a different block
@@ -44,7 +48,7 @@ const Canvas: React.FC<CanvasProps> = ({ showDebug }) => {
         <div className="mb-6 px-6 pt-6">
           <div className="flex flex-col gap-4 mb-4">
             <h2 className="text-2xl font-semibold text-white">
-              {pageSchema.title}
+              {currentPage.title}
             </h2>
             
             {/* Render Context Controls */}
@@ -133,7 +137,7 @@ const Canvas: React.FC<CanvasProps> = ({ showDebug }) => {
               </div>
             </div>
             
-            <p className="text-gray-400">Rendering {pageSchema.blocks.length} blocks</p>
+            <p className="text-gray-400">Rendering {currentPage.blocks.length} blocks</p>
             {showDebug && (
               <>
                 <p className="text-xs text-yellow-400 mt-2 bg-gray-700 p-2 rounded flex items-center gap-2">
@@ -149,7 +153,7 @@ const Canvas: React.FC<CanvasProps> = ({ showDebug }) => {
         </div>
         
         <div className="space-y-0 px-6">
-          {pageSchema.blocks.map((block: Block) => (
+          {currentPage.blocks.map((block: Block) => (
             <div key={block.id} data-block-id={block.id}>
               <BlockInsertDropdown position="above" blockId={block.id} visibilityContext={visibilityContext} />
               <BlockRenderer 

--- a/src/layout/TopBar.tsx
+++ b/src/layout/TopBar.tsx
@@ -1,70 +1,47 @@
-import React from 'react';
-import { Undo, Redo, Plus, X, ChevronDown,Layers } from 'lucide-react';
+import { Undo, Redo, Plus, X, Layers } from 'lucide-react';
 import { useHistory } from '@context/HistoryContext';
 import { useLibraryPanel } from '@context/LibraryPanelContext';
 import { useLayoutPanel } from '@context/LayoutPanelContext';
 import { usePanelCoordinator } from '@context/PanelCoordinator';
-import { usePageSchema, availablePageSchemas, type PageSchemaKey } from '@context/PageSchemaContext';
-import { useOnClickOutside } from '@hooks/useOnClickOutside';
+import { usePageSchema } from '@context/PageSchemaContext';
 import type { PageSchema } from '@blocks/shared/Page';
 
 type TopBarProps = {
-  onSave?: (schema: PageSchema) => void;
+  onSave?: (pageSlug: string, schema: PageSchema) => void;
 };
 
 const TopBar = ({ onSave }: TopBarProps) => {
-  const { undo, canUndo, redo, canRedo, updatePageSchema, pageSchema } = useHistory();
+  const { undo, canUndo, redo, canRedo, pageSchema } = useHistory();
   const { isLibraryOpen } = useLibraryPanel();
   const { isLayoutOpen } = useLayoutPanel();
   const { toggleLibrarySafely, toggleLayoutSafely } = usePanelCoordinator();
-  const { currentPageSchemaKey, setCurrentPageSchemaKey } = usePageSchema();
-  
-  const [isPageSchemaDropdownOpen, setIsPageSchemaDropdownOpen] = React.useState(false);
-  const dropdownRef = React.useRef<HTMLDivElement>(null);
-  
-  useOnClickOutside(dropdownRef, () => setIsPageSchemaDropdownOpen(false));
-  
-  const handlePageSchemaChange = (pageSchemaKey: PageSchemaKey) => {
-    // This logic is moved from the hook - orchestrating both contexts
-    const newPageSchema = availablePageSchemas[pageSchemaKey].pageSchema;
-    setCurrentPageSchemaKey(pageSchemaKey);
-    updatePageSchema(newPageSchema);
-    setIsPageSchemaDropdownOpen(false);
-  };
+  const { 
+    currentPageSlug, 
+    setCurrentPageSlug,
+    pages 
+  } = usePageSchema();
 
   const handleSave = () => {
-    onSave?.(pageSchema);
+    onSave?.(currentPageSlug, pageSchema);
   };
 
   return (
     <div className="sticky top-0 left-0 right-0 z-50 bg-gray-800 text-white p-4 border-b border-gray-700">
       <div className="flex items-center justify-between">
         <div className="flex items-center space-x-3">
-          {/* Page Schema Selector - Choose between Netflix and Hotstar page layouts */}
-          <div className="relative" ref={dropdownRef}>
-            <button
-              onClick={() => setIsPageSchemaDropdownOpen(!isPageSchemaDropdownOpen)}
-              className="px-3 py-2 bg-gray-700 hover:bg-gray-600 rounded flex items-center space-x-2"
+          {/* Page Switcher - Switch between different pages */}
+          <div className="relative">
+            <select
+              value={currentPageSlug}
+              onChange={e => setCurrentPageSlug(e.target.value)}
+              className="px-3 py-2 bg-gray-700 hover:bg-gray-600 rounded border border-gray-600 text-white text-sm"
             >
-              <span>{availablePageSchemas[currentPageSchemaKey].name}</span>
-              <ChevronDown size={16} className={`transition-transform ${isPageSchemaDropdownOpen ? 'rotate-180' : ''}`} />
-            </button>
-            
-            {isPageSchemaDropdownOpen && (
-              <div className="absolute top-full left-0 mt-1 bg-gray-700 rounded shadow-lg w-48 z-50">
-                {Object.entries(availablePageSchemas).map(([key, { name }]) => (
-                  <button
-                    key={key}
-                    onClick={() => handlePageSchemaChange(key as PageSchemaKey)}
-                    className={`w-full text-left px-4 py-2 hover:bg-gray-600 ${
-                      currentPageSchemaKey === key ? 'bg-blue-600' : ''
-                    }`}
-                  >
-                    {name}
-                  </button>
-                ))}
-              </div>
-            )}
+              {Object.keys(pages).map(slug => (
+                <option key={slug} value={slug} className="bg-gray-700 text-white">
+                  {slug.charAt(0).toUpperCase() + slug.slice(1)}
+                </option>
+              ))}
+            </select>
           </div>
           
           <button 

--- a/src/layout/TopBar.tsx
+++ b/src/layout/TopBar.tsx
@@ -17,8 +17,8 @@ const TopBar = ({ onSave }: TopBarProps) => {
   const { toggleLibrarySafely, toggleLayoutSafely } = usePanelCoordinator();
   const { 
     currentPageSlug, 
-    setCurrentPageSlug,
-    pages 
+    loadPage,
+    pagesList 
   } = usePageSchema();
 
   const handleSave = () => {
@@ -33,10 +33,10 @@ const TopBar = ({ onSave }: TopBarProps) => {
           <div className="relative">
             <select
               value={currentPageSlug}
-              onChange={e => setCurrentPageSlug(e.target.value)}
+              onChange={e => loadPage(e.target.value)}
               className="px-3 py-2 bg-gray-700 hover:bg-gray-600 rounded border border-gray-600 text-white text-sm"
             >
-              {Object.keys(pages).map(slug => (
+              {pagesList.map(slug => (
                 <option key={slug} value={slug} className="bg-gray-700 text-white">
                   {slug.charAt(0).toUpperCase() + slug.slice(1)}
                 </option>


### PR DESCRIPTION
This PR refactors the studio to support multiple pages simultaneously instead of switching between predefined templates. 

**Key changes:**
- Multi-page management: Users can switch between pages via dropdown in TopBar
- Page-specific saves: Save callback now includes pageSlug parameter for external systems
- Auto-clear selection: Selection state clears when switching pages to prevent confusion
- Unified history: History management automatically syncs with current page - when switching pages, history is cleared and the new page's state is loaded,