### PR TITLE
feat: Implement builder configuration for block restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,18 @@ Renders the Flimix Studio interface into a DOM element.
     theme: 'dark', // or 'light'
     blocks: [] // Array of block objects
   },
-  onSavePage: async function(id, schema) {
+  // Optional: Restrict available blocks (Whitelist)
+  // If provided, only these blocks will be available.
+  allowedBlocks: ['hero', 'text', 'image'],
+
+  // Optional: Restrict specific blocks (Blacklist)
+  // Ignored if allowedBlocks is provided.
+  restrictedBlocks: ['navigation-container', 'contentLibrary'],
+
+  // Optional: Maximum number of blocks allowed on the page
+  maxBlockCount: 15,
+
+  onSavePage: async function(schema) {
     // Handle page saving - called when user saves a page
     // Return a Promise
   }

--- a/src/PageBuilder.tsx
+++ b/src/PageBuilder.tsx
@@ -6,17 +6,29 @@ import LayoutPanel from '@layout/LayoutPanel';
 import { PageBuilderProviders } from './PageBuilderProviders';
 import { useState } from 'react';
 import type { PageSchema } from '@type/page';
+import type { BlockType } from '@type/block';
 import amazonSchemaData from '@fixtures/amazonSchema.json';
 import { contentApi, type ContentSearchParams, type Content, type ContentType } from '@api/content';
 
 export type PageBuilderProps = {
   schema?: PageSchema;
+  allowedBlocks?: BlockType['type'][];
+  restrictedBlocks?: BlockType['type'][];
+  maxBlockCount?: number;
   onSavePage?: (schema: PageSchema) => Promise<void>;
   onSearchContent?: (params: ContentSearchParams, signal?: AbortSignal) => Promise<Content[]>;
   onFetchContentTypes?: (signal?: AbortSignal) => Promise<ContentType[]>;
 };
 
-function PageBuilder({ schema, onSavePage, onSearchContent, onFetchContentTypes }: PageBuilderProps) {
+function PageBuilder({ 
+  schema, 
+  allowedBlocks,
+  restrictedBlocks,
+  maxBlockCount,
+  onSavePage, 
+  onSearchContent, 
+  onFetchContentTypes 
+}: PageBuilderProps) {
   const [showDebug, setShowDebug] = useState(false);
   const initialSchema = schema || (amazonSchemaData as PageSchema);
 
@@ -27,8 +39,14 @@ function PageBuilder({ schema, onSavePage, onSearchContent, onFetchContentTypes 
     contentApi.setFetchContentTypesCallback(onFetchContentTypes);
   }
 
+  const builderConfig = {
+    allowedBlocks,
+    restrictedBlocks,
+    maxBlockCount,
+  };
+
   return (
-    <PageBuilderProviders initialSchema={initialSchema}>
+    <PageBuilderProviders initialSchema={initialSchema} builderConfig={builderConfig}>
       <div className="min-h-screen flex flex-col bg-black relative flimix-studio">
         <PageBuilderTopbar onSavePage={onSavePage} />
         <div className="flex-1 flex min-h-0">

--- a/src/PageBuilderProviders.tsx
+++ b/src/PageBuilderProviders.tsx
@@ -3,29 +3,41 @@ import { BlockEditingProvider } from '@context/BlockEditingContext';
 import { HistoryProvider } from '@context/HistoryContext';
 import { BlockInsertProvider } from '@context/BlockInsertContext';
 import { PanelProvider } from '@context/PanelContext';
+import { BuilderConfigProvider } from '@context/BuilderConfigContext';
 import type { PageSchema } from '@type/page';
+import type { BlockType } from '@type/block';
 import type { ReactNode } from 'react';
+
+interface BuilderConfig {
+  allowedBlocks?: BlockType['type'][];
+  restrictedBlocks?: BlockType['type'][];
+  maxBlockCount?: number;
+}
 
 interface PageBuilderProvidersProps {
   initialSchema: PageSchema;
+  builderConfig?: BuilderConfig;
   children: ReactNode;
 }
 
 export function PageBuilderProviders({ 
-  initialSchema, 
+  initialSchema,
+  builderConfig,
   children 
 }: PageBuilderProvidersProps) {
   return (
-    <HistoryProvider initialSchema={initialSchema}>
-      <SelectionProvider>
-        <BlockEditingProvider>
-          <BlockInsertProvider>
-            <PanelProvider>
-              {children}
-            </PanelProvider>
-          </BlockInsertProvider>
-        </BlockEditingProvider>
-      </SelectionProvider>
-    </HistoryProvider>
+    <BuilderConfigProvider config={builderConfig}>
+      <HistoryProvider initialSchema={initialSchema}>
+        <SelectionProvider>
+          <BlockEditingProvider>
+            <BlockInsertProvider>
+              <PanelProvider>
+                {children}
+              </PanelProvider>
+            </BlockInsertProvider>
+          </BlockEditingProvider>
+        </SelectionProvider>
+      </HistoryProvider>
+    </BuilderConfigProvider>
   );
 }

--- a/src/context/BlockInsertContext.tsx
+++ b/src/context/BlockInsertContext.tsx
@@ -4,6 +4,7 @@ import { createBlock, findBlockPositionById, findBlockAndParent, updateBlockInTr
 import { getAvailableBlockTypes } from '@type/library';
 import { useHistory } from './HistoryContext';
 import { useSelection } from './SelectionContext';
+import { useBuilderConfig } from './BuilderConfigContext';
 import type { TabsBlock } from '@blocks/tabs/schema';
 
 // Const for insertion position relative to selected block
@@ -66,12 +67,29 @@ export const BlockInsertProvider: React.FC<BlockInsertProviderProps> = ({ childr
     setSelectedItemBlockId,
     activeTabId
   } = useSelection();
+  const { isBlockAllowed, canAddMoreBlocks } = useBuilderConfig();
 
   // Helper function to validate block types
   const isBlockTypeValid = (blockType: string): boolean => {
     const availableTypes = getAvailableBlockTypes();
     if (!availableTypes.includes(blockType)) {
       console.error(`Invalid block type: ${blockType}. Available types: ${availableTypes.join(', ')}`);
+      return false;
+    }
+    
+    // Check allowed/restricted blocks
+    if (!isBlockAllowed(blockType as BlockType['type'])) {
+      console.warn(`Block type '${blockType}' is not allowed in this builder configuration`);
+      return false;
+    }
+    
+    return true;
+  };
+
+  // Helper function to check if more blocks can be added
+  const canInsertBlock = (): boolean => {
+    if (!canAddMoreBlocks(pageSchema.blocks.length)) {
+      console.warn('Cannot add more blocks: maximum block count reached');
       return false;
     }
     return true;
@@ -141,6 +159,10 @@ export const BlockInsertProvider: React.FC<BlockInsertProviderProps> = ({ childr
     if (!selectedBlockId) return;
 
     if (!isBlockTypeValid(blockType)) {
+      return;
+    }
+
+    if (!canInsertBlock()) {
       return;
     }
 
@@ -237,6 +259,10 @@ export const BlockInsertProvider: React.FC<BlockInsertProviderProps> = ({ childr
       return;
     }
 
+    if (!canInsertBlock()) {
+      return;
+    }
+
     let newBlock;
     try {
       newBlock = createBlock(blockType);
@@ -308,6 +334,10 @@ export const BlockInsertProvider: React.FC<BlockInsertProviderProps> = ({ childr
     if (!isBlockTypeValid(blockType)) {
       return;
     }
+
+    if (!canInsertBlock()) {
+      return;
+    }
     let newBlock;
     try {
       newBlock = createBlock(blockType);
@@ -353,6 +383,10 @@ export const BlockInsertProvider: React.FC<BlockInsertProviderProps> = ({ childr
     }
   ) => {
     if (!isBlockTypeValid(blockType) || blockType === 'rowLayout') {
+      return;
+    }
+
+    if (!canInsertBlock()) {
       return;
     }
 

--- a/src/context/BuilderConfigContext.tsx
+++ b/src/context/BuilderConfigContext.tsx
@@ -1,0 +1,118 @@
+import React, { createContext, useContext, useMemo } from 'react';
+import type { BlockType } from '../types/block';
+import { getAvailableBlockTypes } from '../types/library';
+
+interface BuilderConfig {
+  allowedBlocks?: BlockType['type'][];
+  restrictedBlocks?: BlockType['type'][];
+  maxBlockCount?: number;
+}
+
+interface BuilderConfigContextValue {
+  config: BuilderConfig;
+  isBlockAllowed: (blockType: BlockType['type']) => boolean;
+  canAddMoreBlocks: (currentCount: number) => boolean;
+  getFilteredBlocks: <T extends { type: BlockType['type'] }>(blocks: T[]) => T[];
+}
+
+const BuilderConfigContext = createContext<BuilderConfigContextValue | undefined>(undefined);
+
+// Validate and sanitize config on initialization
+const sanitizeConfig = (config?: BuilderConfig): BuilderConfig => {
+  if (!config) return {};
+
+  const allValidTypes = getAvailableBlockTypes();
+  const result: BuilderConfig = {};
+
+  // Helper to filter valid blocks
+  const filterValidBlocks = (blocks: BlockType['type'][], contextName: string) => {
+    return blocks.filter((type) => {
+      const isValid = allValidTypes.includes(type);
+      if (!isValid) {
+        console.warn(`[BuilderConfig] Invalid block type in ${contextName}: "${type}". Ignoring.`);
+      }
+      return isValid;
+    });
+  };
+
+  if (config.allowedBlocks) {
+    const validAllowed = filterValidBlocks(config.allowedBlocks, 'allowedBlocks');
+
+    if (validAllowed.length > 0) {
+      result.allowedBlocks = validAllowed;
+    } else {
+      console.warn('[BuilderConfig] No valid blocks in allowedBlocks. Allowing all blocks.');
+    }
+  }
+
+  // Validate and filter restrictedBlocks (only if allowedBlocks not set)
+  if (config.restrictedBlocks && !result.allowedBlocks) {
+    const validRestricted = filterValidBlocks(config.restrictedBlocks, 'restrictedBlocks');
+
+    if (validRestricted.length > 0) {
+      result.restrictedBlocks = validRestricted;
+    }
+  } else if (config.restrictedBlocks && result.allowedBlocks) {
+    console.info('[BuilderConfig] Both allowedBlocks and restrictedBlocks provided. Using allowedBlocks only.');
+  }
+
+  // Validate maxBlockCount
+  if (config.maxBlockCount !== undefined) {
+    if (typeof config.maxBlockCount === 'number' && config.maxBlockCount > 0) {
+      result.maxBlockCount = config.maxBlockCount;
+    } else {
+      console.warn('[BuilderConfig] Invalid maxBlockCount. Must be positive number. Ignoring.');
+    }
+  }
+
+  return result;
+};
+
+
+export const BuilderConfigProvider: React.FC<{
+  config?: BuilderConfig;
+  children: React.ReactNode;
+}> = ({ config, children }) => {
+  const sanitizedConfig = useMemo(() => sanitizeConfig(config), [config]);
+
+  const isBlockAllowed = (blockType: BlockType['type']): boolean => {
+    // If allowedBlocks is set, use whitelist
+    if (sanitizedConfig.allowedBlocks) {
+      return sanitizedConfig.allowedBlocks.includes(blockType);
+    }
+
+    // If restrictedBlocks is set, use blacklist
+    if (sanitizedConfig.restrictedBlocks) {
+      return !sanitizedConfig.restrictedBlocks.includes(blockType);
+    }
+
+    // No restrictions
+    return true;
+  };
+
+  const canAddMoreBlocks = (currentCount: number): boolean => {
+    if (sanitizedConfig.maxBlockCount === undefined) return true;
+    return currentCount < sanitizedConfig.maxBlockCount;
+  };
+
+  const getFilteredBlocks = <T extends { type: BlockType['type'] }>(blocks: T[]): T[] => {
+    return blocks.filter((block) => isBlockAllowed(block.type));
+  };
+
+  const value: BuilderConfigContextValue = {
+    config: sanitizedConfig,
+    isBlockAllowed,
+    canAddMoreBlocks,
+    getFilteredBlocks,
+  };
+
+  return <BuilderConfigContext.Provider value={value}>{children}</BuilderConfigContext.Provider>;
+};
+
+export const useBuilderConfig = (): BuilderConfigContextValue => {
+  const context = useContext(BuilderConfigContext);
+  if (!context) {
+    throw new Error('useBuilderConfig must be used within a BuilderConfigProvider');
+  }
+  return context;
+};

--- a/src/context/BuilderConfigContext.tsx
+++ b/src/context/BuilderConfigContext.tsx
@@ -37,11 +37,10 @@ const sanitizeConfig = (config?: BuilderConfig): BuilderConfig => {
 
   if (config.allowedBlocks) {
     const validAllowed = filterValidBlocks(config.allowedBlocks, 'allowedBlocks');
+    result.allowedBlocks = validAllowed;
 
-    if (validAllowed.length > 0) {
-      result.allowedBlocks = validAllowed;
-    } else {
-      console.warn('[BuilderConfig] No valid blocks in allowedBlocks. Allowing all blocks.');
+    if (config.allowedBlocks.length > 0 && validAllowed.length === 0) {
+      console.warn('[BuilderConfig] `allowedBlocks` contained only invalid types, so no blocks will be allowed.');
     }
   }
 

--- a/src/layout/BlockInsertDropdown.tsx
+++ b/src/layout/BlockInsertDropdown.tsx
@@ -3,6 +3,7 @@ import type { BlockType } from '@type/block';
 import type { VisibilityContext, VisibilityProps, Platform } from '@type/visibility';
 import { useSelection } from '@context/SelectionContext';
 import { useBlockInsert } from '@context/BlockInsertContext';
+import { useBuilderConfig } from '@context/BuilderConfigContext';
 import { Plus, Type, Layout, Square, Grid2x2, GalleryHorizontalEnd, AlignVerticalSpaceBetween, Minus, MessageSquare, Sparkles, HelpCircle, Image, Video, Columns3Cog, CreditCard, RectangleEllipsis, Search } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { useHistory } from '@context/HistoryContext';
@@ -293,6 +294,7 @@ const BlockInsertDropdown: React.FC<BlockInsertDropdownProps> = ({
   const { selectedBlockId } = useSelection();
   const { insertBlockAfter, insertBlockBefore, insertBlockIntoTabs } = useBlockInsert();
   const { pageSchema } = useHistory();
+  const { getFilteredBlocks } = useBuilderConfig();
 
   // State
   const [isOpen, setIsOpen] = useState(false);
@@ -350,7 +352,9 @@ const BlockInsertDropdown: React.FC<BlockInsertDropdownProps> = ({
   const allTemplates = getAllBlockLibraryItems().filter(
     item => item.type !== 'contentLibrary'
   );
-  const contextFilteredTemplates = filterTemplatesByContext(allTemplates, selectedBlockId, pageSchema.blocks);
+  // Filter by allowed blocks
+  const allowedTemplates = getFilteredBlocks(allTemplates);
+  const contextFilteredTemplates = filterTemplatesByContext(allowedTemplates, selectedBlockId, pageSchema.blocks);
   const searchFilteredTemplates = filterTemplatesBySearch(contextFilteredTemplates, searchQuery);
 
   // Render

--- a/src/layout/LibraryPanel.tsx
+++ b/src/layout/LibraryPanel.tsx
@@ -3,6 +3,7 @@ import { Type, Layout, Square, Grid2x2, GalleryHorizontalEnd, AlignVerticalSpace
 import type { LucideIcon } from 'lucide-react';
 import { useSelection } from '@context/SelectionContext';
 import { useBlockInsert } from '@context/BlockInsertContext';
+import { useBuilderConfig } from '@context/BuilderConfigContext';
 import { getAllBlockLibraryItems } from '@type/library';
 import type { BlockType } from '@type/block';
 import { useHistory } from '@context/HistoryContext';
@@ -34,6 +35,7 @@ const LibraryPanel: React.FC = () => {
   const { selectedBlockId, selectedBlock } = useSelection();
   const { insertBlockAfter, insertBlockAtEnd, insertBlockInsideSection, insertBlockIntoTabs } = useBlockInsert();
   const { pageSchema } = useHistory();
+  const { getFilteredBlocks, canAddMoreBlocks, config } = useBuilderConfig();
   const [searchQuery, setSearchQuery] = useState('');
 
   // Helper function to check if a block is a child of a Section or Tab
@@ -78,19 +80,23 @@ const LibraryPanel: React.FC = () => {
   // Get all block templates using the helper function
   const allTemplates = getAllBlockLibraryItems();
   
-  // Filter templates based on search query
+  // Filter by allowed blocks first
+  const allowedTemplates = getFilteredBlocks(allTemplates);
+  
+  // Then filter templates based on search query
   const filteredTemplates = searchQuery 
-    ? allTemplates.filter(template => 
+    ? allowedTemplates.filter(template => 
         template.name.toLowerCase().includes(searchQuery.toLowerCase()) || 
         template.description.toLowerCase().includes(searchQuery.toLowerCase())
       )
-    : allTemplates;
+    : allowedTemplates;
 
   const contentLibraryTemplate = filteredTemplates.find(t => t.type === 'contentLibrary');
   const regularTemplates = filteredTemplates.filter(t => t.type !== 'contentLibrary');
 
   const isContentLibraryPresent = pageSchema.blocks.some(block => block.type === ('contentLibrary' as BlockType['type']));
   const hasBlocks = pageSchema.blocks.length > 0;
+  const isLimitReached = !canAddMoreBlocks(pageSchema.blocks.length);
 
   const handleBlockInsert = (blockType: BlockType['type']) => {
     if (!selectedBlock) {
@@ -161,6 +167,22 @@ const LibraryPanel: React.FC = () => {
             />
           </div>
         </div>
+        {/* Restriction Info */}
+        {(config.allowedBlocks || config.maxBlockCount) && (
+          <div className="mt-2 text-xs text-blue-600 bg-blue-50 px-3 py-2 rounded">
+            {config.allowedBlocks && (
+              <div>Showing {allowedTemplates.length} allowed block types</div>
+            )}
+            {config.maxBlockCount && (
+              <div className="mt-1">
+                Block limit: {pageSchema.blocks.length}/{config.maxBlockCount}
+                {pageSchema.blocks.length >= config.maxBlockCount && (
+                  <span className="text-red-600 ml-1">(Maximum reached)</span>
+                )}
+              </div>
+            )}
+          </div>
+        )}
       </div>
       {/* Block Templates */}
       <div className="flex-1 min-h-0 overflow-y-auto p-4 scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-gray-100">
@@ -188,6 +210,9 @@ const LibraryPanel: React.FC = () => {
                    } else if (hasBlocks && (template.type as string) === 'contentLibrary') {
                       isDisabled = true;
                       tooltipMessage = "This block requires an empty page. Please remove other blocks first.";
+                   } else if (isLimitReached) {
+                      isDisabled = true;
+                      tooltipMessage = "Maximum block limit reached. Cannot add more blocks.";
                    }
 
                    return (
@@ -244,6 +269,9 @@ const LibraryPanel: React.FC = () => {
                 if (isContentLibraryPresent) {
                    isDisabled = true;
                    tooltipMessage = "Content Library takes up the entire page. Remove it to add other blocks.";
+                } else if (isLimitReached) {
+                   isDisabled = true;
+                   tooltipMessage = "Maximum block limit reached. Cannot add more blocks.";
                 }
 
                 return (


### PR DESCRIPTION
- Introduces a configuration system to validate and restrict allowed block types
- Adds support for limiting the maximum number of blocks per page
- Updates the library panel and menus to filter blocks based on active restrictions
- Displays UI feedback when block limits are reached or restrictions apply
- Prevents block insertion programmatically if validation fails